### PR TITLE
Inference wrapper implementation and basic test

### DIFF
--- a/tinker_atropos/inference/wrapper.py
+++ b/tinker_atropos/inference/wrapper.py
@@ -1,14 +1,33 @@
 from typing import List
+from tinker.types import ModelInput, SamplingParams
+
+import asyncio
 import tinker
 
 
 # Wraps Tinker SamplingClient for use with Atropos environments.
 class TinkerInferenceWrapper:
-    def __init__(self, service_client: tinker.ServiceClient, base_model: str):
+    def __init__(
+        self,
+        service_client: tinker.ServiceClient,
+        base_model: str,
+        initial_sampling_client: tinker.SamplingClient | None = None,
+    ):
         self.service_client = service_client
         self.base_model = base_model
-        self.current_sampling_client = None
-        self.tokenizer = None  # TODO: figure out tokenizer
+
+        # Set up initial sampling client
+        if initial_sampling_client is None:
+            self.current_sampling_client = service_client.create_sampling_client(
+                base_model=base_model
+            )
+        else:
+            self.current_sampling_client = initial_sampling_client
+
+        # Get tokenizer from training client (or sampling client if available)
+        # TODO: Figure out the best way to get tokenizer
+        # This will probably be pulling and loading the one from HF based on basemodel params
+        self.tokenizer = None
 
     async def generate(
         self,
@@ -18,9 +37,55 @@ class TinkerInferenceWrapper:
         stop: List[str] | None = None,
         **kwargs,
     ) -> List[str]:
-        # TODO: implement
-        raise NotImplementedError()
+        # Convert prompts to ModelInput and generate
+        tasks = [
+            self._generate_one(self.current_sampling_client, prompt, max_tokens, temperature, stop)
+            for prompt in prompts
+        ]
+        completions = await asyncio.gather(*tasks)
+        return completions
+
+    async def _generate_one(
+        self,
+        client: tinker.SamplingClient,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        stop: List[str] | None,
+    ) -> str:
+        # TODO: Need tokenizer to convert prompt string to tokens
+        # For now, assuming we can get tokens somehow
+        if self.tokenizer is None:
+            raise RuntimeError("Tokenizer not initialized. Need to set up tokenizer.")
+
+        # Encode prompt to tokens
+        tokens = self.tokenizer.encode(prompt, add_special_tokens=True)
+        model_input = ModelInput.from_ints(tokens)
+
+        # Create sampling params
+        sampling_params = SamplingParams(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stop=stop if stop else [],
+        )
+
+        # Sample from Tinker (doub le await pattern)
+        result_future = await client.sample_async(
+            prompt=model_input,
+            sampling_params=sampling_params,
+            num_samples=1,
+        )
+        result = await result_future.result_async()
+
+        # Decode tokens back to string
+        completion_tokens = result.sequences[0].tokens
+        completion_text = self.tokenizer.decode(completion_tokens)
+
+        return completion_text
 
     async def update_weights(self, model_path: str) -> None:
-        # TODO: implement
-        raise NotImplementedError()
+        new_client = self.service_client.create_sampling_client(model_path=model_path)
+
+        self.current_sampling_client = new_client
+
+        print(f"Updated inference weights to: {model_path}")

--- a/tinker_atropos/inference/wrapper.py
+++ b/tinker_atropos/inference/wrapper.py
@@ -67,13 +67,12 @@ class TinkerInferenceWrapper:
             stop=stop if stop else [],
         )
 
-        # Sample from Tinker (double await pattern)
-        result_future = await client.sample_async(
+        # Sample from Tinker
+        result = await client.sample_async(
             prompt=model_input,
             sampling_params=sampling_params,
             num_samples=1,
         )
-        result = await result_future.result_async()
 
         # Decode tokens back to string
         completion_tokens = result.sequences[0].tokens

--- a/tinker_atropos/inference/wrapper.py
+++ b/tinker_atropos/inference/wrapper.py
@@ -1,5 +1,6 @@
 from typing import List
 from tinker.types import ModelInput, SamplingParams
+from transformers import AutoTokenizer
 
 import asyncio
 import tinker
@@ -24,10 +25,9 @@ class TinkerInferenceWrapper:
         else:
             self.current_sampling_client = initial_sampling_client
 
-        # Get tokenizer from training client (or sampling client if available)
-        # TODO: Figure out the best way to get tokenizer
-        # This will probably be pulling and loading the one from HF based on basemodel params
-        self.tokenizer = None
+        # Get tokenizer from HuggingFace
+        self.tokenizer = AutoTokenizer.from_pretrained(base_model)
+        print(f"Loaded tokenizer for {base_model}")
 
     async def generate(
         self,
@@ -53,8 +53,6 @@ class TinkerInferenceWrapper:
         temperature: float,
         stop: List[str] | None,
     ) -> str:
-        # TODO: Need tokenizer to convert prompt string to tokens
-        # For now, assuming we can get tokens somehow
         if self.tokenizer is None:
             raise RuntimeError("Tokenizer not initialized. Need to set up tokenizer.")
 
@@ -69,7 +67,7 @@ class TinkerInferenceWrapper:
             stop=stop if stop else [],
         )
 
-        # Sample from Tinker (doub le await pattern)
+        # Sample from Tinker (double await pattern)
         result_future = await client.sample_async(
             prompt=model_input,
             sampling_params=sampling_params,

--- a/tinker_atropos/tests/test_wrapper_manual.py
+++ b/tinker_atropos/tests/test_wrapper_manual.py
@@ -1,0 +1,42 @@
+"""Manual test for TinkerInferenceWrapper - run this to verify it works."""
+import asyncio
+import os
+import tinker
+from tinker_atropos.inference.wrapper import TinkerInferenceWrapper
+
+
+async def main():
+    if not os.getenv("TINKER_API_KEY"):
+        print("ERROR: Set TINKER_API_KEY environment variable")
+        return
+
+    print("Creating Tinker service client...")
+    service_client = tinker.ServiceClient()
+
+    base_model = "meta-llama/Llama-3.1-8B"
+    print(f"Creating wrapper for {base_model}...")
+
+    wrapper = TinkerInferenceWrapper(service_client, base_model)
+
+    # Test generate
+    print("\nTesting generation...")
+    prompts = ["What is 2+2?", "What is the capital of France?"]
+
+    try:
+        completions = await wrapper.generate(
+            prompts=prompts,
+            max_tokens=50,
+            temperature=0.7,
+        )
+
+        print("\nSuccess! Generated completions:")
+        for i, (prompt, completion) in enumerate(zip(prompts, completions)):
+            print(f"\n[{i}] Prompt: {prompt}")
+            print(f"    Completion: {completion}")
+
+    except Exception as e:
+        print(f"\nError: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Added the main changes for the Tinker inference wrapper implementation. As for using a Tokenizer, I'm still not sure what the right pattern should be here. 

Do we want to integrate some way of passing tokens directly and not needing the tokenizer to encode and decode inside the `generate` method? This would probably require Atropos changes, so in the spirit of decoupling I'm fine with what's proposed here.

Verified testing script works with Tinker Service client inference :-) 