### PR TITLE
Adding 'n' parameter to chat completions

### DIFF
--- a/tinker_atropos/inference/server.py
+++ b/tinker_atropos/inference/server.py
@@ -90,21 +90,23 @@ async def chat_completions(request: ChatCompletionRequest):
         prompt = wrapper.messages_to_prompt(messages_dict)
 
         completions_list = await wrapper.generate(
-            prompts=[prompt],
+            prompt=prompt,
             max_tokens=request.max_tokens,
             temperature=request.temperature,
             stop=request.stop,
+            num_samples=request.n,
         )
 
         choices = [
             {
                 "message": {
                     "role": "assistant",
-                    "content": completions_list[0],
+                    "content": completion,
                 },
-                "index": 0,
+                "index": i,
                 "finish_reason": "stop",
             }
+            for i, completion in enumerate(completions_list)
         ]
 
         return ChatCompletionResponse(

--- a/tinker_atropos/inference/wrapper.py
+++ b/tinker_atropos/inference/wrapper.py
@@ -2,7 +2,6 @@ from typing import List, Dict
 from tinker.types import ModelInput, SamplingParams
 from transformers import AutoTokenizer
 
-import asyncio
 import tinker
 
 
@@ -31,28 +30,12 @@ class TinkerInferenceWrapper:
 
     async def generate(
         self,
-        prompts: List[str],
+        prompt: str,
         max_tokens: int = 100,
         temperature: float = 0.7,
         stop: List[str] | None = None,
-        **kwargs,
+        num_samples: int = 1,
     ) -> List[str]:
-        # Convert prompts to ModelInput and generate
-        tasks = [
-            self._generate_one(self.current_sampling_client, prompt, max_tokens, temperature, stop)
-            for prompt in prompts
-        ]
-        completions = await asyncio.gather(*tasks)
-        return completions
-
-    async def _generate_one(
-        self,
-        client: tinker.SamplingClient,
-        prompt: str,
-        max_tokens: int,
-        temperature: float,
-        stop: List[str] | None,
-    ) -> str:
         if self.tokenizer is None:
             raise RuntimeError("Tokenizer not initialized. Need to set up tokenizer.")
 
@@ -67,18 +50,17 @@ class TinkerInferenceWrapper:
             stop=stop if stop else [],
         )
 
-        # Sample from Tinker
-        result = await client.sample_async(
+        # Sample from Tinker with num_samples
+        result = await self.current_sampling_client.sample_async(
             prompt=model_input,
             sampling_params=sampling_params,
-            num_samples=1,
+            num_samples=num_samples,
         )
 
-        # Decode tokens back to string
-        completion_tokens = result.sequences[0].tokens
-        completion_text = self.tokenizer.decode(completion_tokens)
+        # Decode all sequences to strings
+        completions = [self.tokenizer.decode(sequence.tokens) for sequence in result.sequences]
 
-        return completion_text
+        return completions
 
     async def update_weights(self, model_path: str) -> None:
         new_client = self.service_client.create_sampling_client(model_path=model_path)

--- a/tinker_atropos/types.py
+++ b/tinker_atropos/types.py
@@ -36,6 +36,7 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: int = 100
     temperature: float = 0.7
     stop: List[str] | None = None
+    n: int = 1
 
 
 # Response format for /v1/chat/completions endpoint.


### PR DESCRIPTION
Adding support for the 'n' parameter in chat completions request, which leverages the `num_samples` param for Tinker API inference requests. Tested with independent API calls and e2e with the existing environment from `sample-env` branch.

NOTE: will rebase the `sample-env` branch here before merging