### PR TITLE
Adding n parameter to regular completions endpoint

### DIFF
--- a/tinker_atropos/inference/server.py
+++ b/tinker_atropos/inference/server.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI, HTTPException
 from tinker_atropos.types import (
     CompletionRequest,
@@ -16,6 +18,8 @@ wrapper: TinkerInferenceWrapper | None = None
 current_model_name: str = "unknown"
 
 app = FastAPI(title="Tinker Inference Service")
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
 @app.on_event("startup")
@@ -46,17 +50,13 @@ async def completions(request: CompletionRequest):
     if wrapper is None:
         raise HTTPException(status_code=503, detail="Wrapper not initialized")
 
-    if isinstance(request.prompt, str):
-        prompts = [request.prompt]
-    else:
-        prompts = request.prompt
-
     try:
         completions_list = await wrapper.generate(
-            prompts=prompts,
+            prompt=request.prompt,
             max_tokens=request.max_tokens,
             temperature=request.temperature,
             stop=request.stop,
+            num_samples=request.n,
         )
 
         choices = [


### PR DESCRIPTION
This PR adds the `n` param to the main completions endpoint, and fixes the tokenizers parallelism warning that's popping up. 

Tested both `/v1/completions` and `/v1/chat/completions` endpoints with `n=8` samples, everything looks good :-) 