### PR TITLE
Implementation with Atropos ManagedServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # tinker-atropos
 Standalone repo for our Atropos integration with Thinking Machines Tinker API (https://thinkingmachines.ai/tinker/)
+
+
+## Testing
+
+Test can be run with `python -m pytest tinker_atropos/tests/ -v`

--- a/tinker_atropos/environments/gsm8k_tinker.py
+++ b/tinker_atropos/environments/gsm8k_tinker.py
@@ -71,10 +71,10 @@ class GSM8kEnv(BaseEnv):
         server_configs = [
             APIServerConfig(
                 model_name="meta-llama/Llama-3.1-8B-Instruct",
-                base_url="http://localhost:8001/v1",  # OpenAI client needs /v1 prefix
+                base_url="http://localhost:8001/v1",
                 api_key="x",
                 num_requests_for_eval=256,
-                server_type="sglang",  # Use SGLang server type for ManagedServer compatibility
+                server_type="sglang",
             ),
         ]
 
@@ -220,17 +220,11 @@ class GSM8kEnv(BaseEnv):
         )
 
     async def collect_trajectories(self, item: GSM8kRow) -> Tuple[ScoredDataGroup, list[Item]]:
-        """
-        Generate multiple rollouts for a single question using ManagedServer.
-        ManagedServer automatically tracks tokens, masks, and logprobs.
-        """
         user_message = {"role": "user", "content": item["question"] + question_suffix}
         gold_answer = "\\boxed{" + item["answer"].split("#")[-1].strip().replace(",", "") + "}"
 
-        # Prepare messages for chat completion
         messages = [*convo_prefix, user_message]
 
-        # Use ManagedServer for automatic token/logprob tracking
         async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
             chat_completion = await managed.chat_completion(
                 messages=messages,
@@ -239,11 +233,9 @@ class GSM8kEnv(BaseEnv):
                 temperature=1.0,
             )
 
-            # Get tracked sequences with pre-aligned tokens and logprobs
             state = managed.get_state()
             nodes = state["nodes"]
 
-        # Extract data from SequenceNodes for scoring
         to_score = list()
         to_backlog = list()
         for choice, node in zip(chat_completion.choices, nodes):
@@ -257,9 +249,9 @@ class GSM8kEnv(BaseEnv):
                     "messages": completion_messages,
                     "gold_answer": gold_answer,
                     "finish_reason": choice.finish_reason,
-                    "tokens": node.tokens,  # Full unmasked tokens
-                    "masked_tokens": node.masked_tokens,  # Pre-masked tokens (-100 for prompt)
-                    "logprobs": node.logprobs,  # Pre-masked logprobs (1.0 for prompt)
+                    "tokens": node.tokens,
+                    "masked_tokens": node.masked_tokens,
+                    "logprobs": node.logprobs,
                 }
             )
         to_postprocess = await self.score(to_score)

--- a/tinker_atropos/environments/gsm8k_tinker.py
+++ b/tinker_atropos/environments/gsm8k_tinker.py
@@ -1,7 +1,6 @@
 import random
 import time
 from typing import Dict, List, Optional, Tuple, TypedDict, Union
-import aiohttp
 
 from datasets import load_dataset
 from latex2sympy2_extended import NormalizationConfig
@@ -72,9 +71,10 @@ class GSM8kEnv(BaseEnv):
         server_configs = [
             APIServerConfig(
                 model_name="meta-llama/Llama-3.1-8B-Instruct",
-                base_url="http://localhost:8001/v1",
+                base_url="http://localhost:8001/v1",  # OpenAI client needs /v1 prefix
                 api_key="x",
                 num_requests_for_eval=256,
+                server_type="sglang",  # Use SGLang server type for ManagedServer compatibility
             ),
         ]
 
@@ -118,52 +118,6 @@ class GSM8kEnv(BaseEnv):
             data = {}
         data["iter"] = self.iter
         super().save_checkpoint(step, data)
-
-    async def _generate_with_logprobs(
-        self,
-        messages: List[Dict[str, str]],
-        n: int = 1,
-        max_tokens: int = 2048,
-        temperature: float = 1.0,
-        stop: Optional[List[str]] = None,
-    ) -> tuple[list, list, list, list]:
-        url = "http://localhost:8001/v1/chat/completions"
-
-        prompt_text = self.tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
-        prompt_tokens = self.tokenizer.encode(prompt_text, add_special_tokens=False)
-
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url,
-                json={
-                    "messages": messages,
-                    "max_tokens": max_tokens,
-                    "temperature": temperature,
-                    "stop": stop if stop else [],
-                    "n": n,
-                },
-            ) as response:
-                result = await response.json()
-
-        output_tokens_list = []
-        output_logprobs_list = []
-        finish_reasons_list = []
-
-        for choice in result["choices"]:
-            # Get full tokens
-            full_tokens = choice["tokens"]
-            logprobs = choice["logprobs"]
-
-            prefix_len = len(prompt_tokens)
-            output_tokens = full_tokens[prefix_len:]
-
-            output_tokens_list.append(output_tokens)
-            output_logprobs_list.append(logprobs)
-            finish_reasons_list.append(choice["finish_reason"])
-
-        return prompt_tokens, output_tokens_list, output_logprobs_list, finish_reasons_list
 
     async def rollout_and_score_eval(self, question: str, answer: str) -> dict:
         """Rollout and score evaluation with detailed sample data collection."""
@@ -266,43 +220,46 @@ class GSM8kEnv(BaseEnv):
         )
 
     async def collect_trajectories(self, item: GSM8kRow) -> Tuple[ScoredDataGroup, list[Item]]:
+        """
+        Generate multiple rollouts for a single question using ManagedServer.
+        ManagedServer automatically tracks tokens, masks, and logprobs.
+        """
         user_message = {"role": "user", "content": item["question"] + question_suffix}
         gold_answer = "\\boxed{" + item["answer"].split("#")[-1].strip().replace(",", "") + "}"
 
+        # Prepare messages for chat completion
         messages = [*convo_prefix, user_message]
-        (
-            prompt_tokens,
-            output_tokens_list,
-            output_logprobs_list,
-            finish_reasons_list,
-        ) = await self._generate_with_logprobs(
-            messages=messages,
-            n=self.config.group_size,
-            max_tokens=self.config.max_token_length,
-        )
 
+        # Use ManagedServer for automatic token/logprob tracking
+        async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
+            chat_completion = await managed.chat_completion(
+                messages=messages,
+                n=self.config.group_size,
+                max_tokens=self.config.max_token_length,
+                temperature=1.0,
+            )
+
+            # Get tracked sequences with pre-aligned tokens and logprobs
+            state = managed.get_state()
+            nodes = state["nodes"]
+
+        # Extract data from SequenceNodes for scoring
         to_score = list()
         to_backlog = list()
-        for i, (output_tokens, logprobs, finish_reason) in enumerate(
-            zip(output_tokens_list, output_logprobs_list, finish_reasons_list)
-        ):
-            full_tokens = prompt_tokens + output_tokens
-
-            output_text = self.tokenizer.decode(output_tokens, skip_special_tokens=True)
-
+        for choice, node in zip(chat_completion.choices, nodes):
             completion_messages = (
                 *convo_prefix,
                 user_message,
-                {"role": "assistant", "content": output_text},
+                {"role": "assistant", "content": choice.message.content},
             )
             to_score.append(
                 {
                     "messages": completion_messages,
                     "gold_answer": gold_answer,
-                    "finish_reason": finish_reason,
-                    "tokens": full_tokens,
-                    "logprobs": logprobs,
-                    "prompt_tokens": prompt_tokens,
+                    "finish_reason": choice.finish_reason,
+                    "tokens": node.tokens,  # Full unmasked tokens
+                    "masked_tokens": node.masked_tokens,  # Pre-masked tokens (-100 for prompt)
+                    "logprobs": node.logprobs,  # Pre-masked logprobs (1.0 for prompt)
                 }
             )
         to_postprocess = await self.score(to_score)
@@ -344,22 +301,21 @@ class GSM8kEnv(BaseEnv):
                     ],
                     extraction_mode="first_match",
                 )
-                # Reward 1 if the content is the same as the ground truth, 0 otherwise
+                # Binary reward: 1 if correct, 0 otherwise
                 reward = verify(answer_parsed, gold_parsed)
 
-                tokens = item["tokens"]
-                prompt_tokens = item["prompt_tokens"]
+                # Use pre-computed tokens and masks from ManagedServer
+                tokens = item["tokens"]  # Full unmasked tokens
+                masked_tokens = item["masked_tokens"]  # Pre-masked (-100 for prompt)
+                logprobs = item["logprobs"]  # Pre-masked (1.0 for prompt)
 
-                # Create masks
-                prefix_len = len(prompt_tokens)
-                masks = [-100] * prefix_len + tokens[prefix_len:]
-
-                # remove obviously bad examples
-                if len([1 for i in masks if i != -100]) < 10:
+                # Skip very short completions (less than 10 generated tokens)
+                if len([1 for i in masked_tokens if i != -100]) < 10:
                     continue
+
                 scores["tokens"].append(tokens)
-                scores["masks"].append(masks)
-                scores["inference_logprobs"].append(item["logprobs"])
+                scores["masks"].append(masked_tokens)
+                scores["inference_logprobs"].append(logprobs)
                 scores["scores"].append(1.0 if reward else 0.0)
                 if len(scores["tokens"]) >= self.config.group_size:
                     break

--- a/tinker_atropos/tests/test_logprob_alignment.py
+++ b/tinker_atropos/tests/test_logprob_alignment.py
@@ -1,0 +1,392 @@
+import pytest
+from tinker_atropos.trainer import TinkerAtroposTrainer
+
+
+@pytest.fixture
+def trainer():
+    trainer = TinkerAtroposTrainer(base_model="meta-llama/Llama-3.1-8B-Instruct")
+    return trainer
+
+
+class TestLogprobAlignment:
+    def test_basic_alignment_lengths(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [[1, 2, 3, 4, 5, 6, 7, 8]],
+                    "inference_logprobs": [[1.0, 1.0, 1.0, 1.0, 0.8, 0.7, 0.6, 0.5]],
+                    "scores": [2.5],
+                }
+            ]
+        }
+
+        datums, group_rewards = trainer.pad_data_to_good_offset(batch_data)
+        assert len(datums) == 1
+
+        datum = datums[0]
+        input_tokens = datum.model_input.to_ints()
+        target_tokens = datum.loss_fn_inputs["target_tokens"].to_torch().tolist()
+        logprobs = datum.loss_fn_inputs["logprobs"].to_torch().tolist()
+        advantages = datum.loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert len(input_tokens) == len(target_tokens) == len(logprobs) == len(advantages) == 7
+
+    def test_advantage_masking_for_prompt_tokens(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3, 4, 5, 6],
+                        [1, 2, 3, 7, 8, 9],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 1.0, 1.0, 0.9, 0.8, 0.7],  # 3 prompt, 3 generated
+                        [1.0, 1.0, 1.0, 0.85, 0.75, 0.65],
+                    ],
+                    "scores": [5.0, 1.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert advantages[0] == 0.0
+        assert advantages[1] == 0.0
+        assert advantages[2] == 2.0
+        assert advantages[3] == 2.0
+        assert advantages[4] == 2.0
+
+    def test_all_prompt_tokens(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [[1, 2, 3, 4]],
+                    "inference_logprobs": [[1.0, 1.0, 1.0, 1.0]],
+                    "scores": [5.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert all(a == 0.0 for a in advantages)
+        assert len(advantages) == 3
+
+    def test_all_generated_tokens(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3, 4, 5],
+                        [6, 7, 8, 9, 10],
+                    ],
+                    "inference_logprobs": [
+                        [0.9, 0.8, 0.7, 0.6, 0.5],
+                        [0.85, 0.75, 0.65, 0.55, 0.45],
+                    ],
+                    "scores": [6.0, 2.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert all(a == 2.0 for a in advantages)
+        assert len(advantages) == 4
+
+    def test_logprob_shift_alignment(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [10, 20, 30, 40, 50],
+                        [10, 20, 30, 40, 51],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 0.9, 0.8, 0.7, 0.6],
+                        [1.0, 0.85, 0.75, 0.65, 0.55],
+                    ],
+                    "scores": [2.0, 1.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+
+        target_tokens = datums[0].loss_fn_inputs["target_tokens"].to_torch().tolist()
+        logprobs = datums[0].loss_fn_inputs["logprobs"].to_torch().tolist()
+
+        assert target_tokens == [20, 30, 40, 50]
+        assert logprobs == pytest.approx([0.9, 0.8, 0.7, 0.6], rel=1e-6)
+
+    def test_zero_advantage_override(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [[1, 2, 3, 4]],
+                    "inference_logprobs": [[1.0, 1.0, 0.8, 0.7]],
+                    "scores": [0.0],  # Zero advantage
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert all(a == 0.0 for a in advantages)
+
+    def test_negative_advantage(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3, 4, 5],
+                        [1, 2, 3, 4, 6],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 1.0, 0.8, 0.7, 0.6],
+                        [1.0, 1.0, 0.85, 0.75, 0.65],
+                    ],
+                    "scores": [1.0, 4.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert advantages[0] == 0.0
+        assert advantages[1] == -1.5
+        assert advantages[2] == -1.5
+        assert advantages[3] == -1.5
+
+    def test_multiple_trajectories_in_group(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3, 4],
+                        [1, 2, 3, 5],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 1.0, 0.9, 0.8],
+                        [1.0, 1.0, 0.85, 0.75],
+                    ],
+                    "scores": [5.0, 3.0],
+                }
+            ]
+        }
+
+        datums, group_rewards = trainer.pad_data_to_good_offset(batch_data)
+
+        assert len(datums) == 2
+        assert len(group_rewards) == 1
+        assert group_rewards[0] == 4.0
+
+        advantages1 = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+        assert advantages1[0] == 0.0
+        assert advantages1[1] == 1.0
+        assert advantages1[2] == 1.0
+
+        advantages2 = datums[1].loss_fn_inputs["advantages"].to_torch().tolist()
+        assert advantages2[0] == 0.0
+        assert advantages2[1] == -1.0
+        assert advantages2[2] == -1.0
+
+    def test_override_set_advantage_to_zero(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3, 4],
+                        [1, 2, 3, 5],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 1.0, 0.9, 0.8],
+                        [1.0, 1.0, 0.85, 0.75],
+                    ],
+                    "scores": [5.0, 3.0],
+                    "overrides": [
+                        {},
+                        {"set_advantage_to_zero": True},
+                    ],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+
+        advantages1 = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+        assert advantages1[1] == 1.0
+
+        advantages2 = datums[1].loss_fn_inputs["advantages"].to_torch().tolist()
+        assert all(a == 0.0 for a in advantages2)
+
+    def test_skip_groups_with_all_zero_advantages(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3],
+                        [1, 2, 4],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 0.9, 0.8],
+                        [1.0, 0.85, 0.75],
+                    ],
+                    "scores": [3.0, 3.0],
+                }
+            ]
+        }
+
+        datums, group_rewards = trainer.pad_data_to_good_offset(batch_data)
+
+        assert len(datums) == 0
+        assert len(group_rewards) == 0
+
+
+class TestLogprobStatistics:
+    def test_logprob_stats_populated(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [[1, 2, 3, 4, 5, 6]],
+                    "inference_logprobs": [[1.0, 1.0, 0.9, 0.8, 0.7, 0.6]],
+                    "scores": [2.0],
+                }
+            ]
+        }
+
+        trainer.pad_data_to_good_offset(batch_data)
+
+        assert hasattr(trainer, "logprob_stats")
+        assert "logprobs/mean" in trainer.logprob_stats
+        assert "logprobs/std" in trainer.logprob_stats
+        assert "logprobs/min" in trainer.logprob_stats
+        assert "logprobs/p50" in trainer.logprob_stats
+
+    def test_logprob_stats_filters_placeholders(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [[1, 2, 3, 4, 5]],
+                    "inference_logprobs": [[1.0, 1.0, 0.8, 0.7, 0.6]],
+                    "scores": [1.0],
+                }
+            ]
+        }
+
+        trainer.pad_data_to_good_offset(batch_data)
+
+        assert trainer.logprob_stats["logprobs/min"] == pytest.approx(0.6)
+        assert 0.65 <= trainer.logprob_stats["logprobs/mean"] <= 0.75
+
+    def test_advantage_stats_populated(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3],
+                        [1, 2, 4],
+                        [1, 2, 5],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 0.9, 0.8],
+                        [1.0, 0.85, 0.75],
+                        [1.0, 0.8, 0.7],
+                    ],
+                    "scores": [5.0, 3.0, 2.0],
+                }
+            ]
+        }
+
+        trainer.pad_data_to_good_offset(batch_data)
+
+        assert hasattr(trainer, "advantage_stats")
+        assert "advantages/mean" in trainer.advantage_stats
+        assert "advantages/std" in trainer.advantage_stats
+        assert "advantages/sum" in trainer.advantage_stats
+
+
+class TestEdgeCases:
+    def test_minimal_two_token_sequence(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2],
+                        [1, 3],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 0.9],
+                        [1.0, 0.8],
+                    ],
+                    "scores": [2.0, 1.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+
+        assert len(datums) == 2
+        input_tokens = datums[0].model_input.to_ints()
+        assert len(input_tokens) == 1
+
+    def test_logprob_boundary_value(self, trainer):
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [
+                        [1, 2, 3, 4, 5],
+                        [1, 2, 3, 4, 6],
+                    ],
+                    "inference_logprobs": [
+                        [1.0, 1.0, 0.99, 0.8, 0.7],
+                        [1.0, 1.0, 0.95, 0.75, 0.65],
+                    ],
+                    "scores": [3.0, 1.0],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        assert advantages[0] == 0.0
+        assert advantages[1] == 1.0
+
+    def test_empty_batch(self, trainer):
+        batch_data = {"batch": []}
+
+        datums, group_rewards = trainer.pad_data_to_good_offset(batch_data)
+
+        assert len(datums) == 0
+        assert len(group_rewards) == 0
+
+    def test_very_long_sequence(self, trainer):
+        n = 100
+        tokens1 = list(range(n))
+        tokens2 = list(range(1000, 1000 + n))
+        logprobs1 = [1.0] * 10 + [0.8] * (n - 10)
+        logprobs2 = [1.0] * 10 + [0.7] * (n - 10)
+
+        batch_data = {
+            "batch": [
+                {
+                    "tokens": [tokens1, tokens2],
+                    "inference_logprobs": [logprobs1, logprobs2],
+                    "scores": [2.5, 1.5],
+                }
+            ]
+        }
+
+        datums, _ = trainer.pad_data_to_good_offset(batch_data)
+
+        assert len(datums) == 2
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+
+        masked_count = sum(1 for a in advantages if a == 0.0)
+        assert masked_count == 9

--- a/tinker_atropos/tests/test_managed_server.py
+++ b/tinker_atropos/tests/test_managed_server.py
@@ -1,0 +1,364 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi.testclient import TestClient
+from tinker.types import SampleResponse, SampledSequence
+
+
+@pytest.fixture
+def mock_trainer():
+    trainer = MagicMock()
+    trainer.base_model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    trainer.tokenizer = MagicMock()
+    trainer.tokenizer.encode = MagicMock(side_effect=lambda text, **kwargs: [1, 2, 3, 4, 5])
+    trainer.tokenizer.decode = MagicMock(return_value="Test output")
+    trainer.tokenizer.apply_chat_template = MagicMock(
+        return_value="System: You are helpful\nUser: Hello"
+    )
+
+    trainer.current_sampling_client = MagicMock()
+
+    mock_sequence = SampledSequence(
+        tokens=[10, 11, 12],
+        logprobs=[0.9, 0.8, 0.7],
+        stop_reason="stop",
+    )
+    mock_result = SampleResponse(sequences=[mock_sequence])
+
+    trainer.current_sampling_client.sample_async = AsyncMock(return_value=mock_result)
+
+    return trainer
+
+
+@pytest.fixture
+def app_with_trainer(mock_trainer):
+    import tinker_atropos.trainer as trainer_module
+
+    original_trainer = trainer_module.trainer
+    trainer_module.trainer = mock_trainer
+
+    # FastAPI TestClient needs an instance of the application as an input parameter
+    yield trainer_module.app
+
+    trainer_module.trainer = original_trainer
+
+
+@pytest.fixture
+def client(app_with_trainer):
+    return TestClient(app_with_trainer)
+
+
+class TestHealthEndpoint:
+    def test_health_with_trainer(self, client):
+        """Test health endpoint when trainer is initialized"""
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["trainer_initialized"] is True
+
+
+class TestCompletionsEndpoint:
+    def test_single_completion(self, client, mock_trainer):
+        """Test single completion request"""
+        request_data = {
+            "prompt": "Once upon a time",
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "n": 1,
+        }
+
+        response = client.post("/v1/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "id" in data
+        assert data["id"].startswith("cmpl-")
+        assert data["model"] == "meta-llama/Llama-3.1-8B-Instruct"
+        assert len(data["choices"]) == 1
+        assert data["choices"][0]["text"] == "Test output"
+        assert data["choices"][0]["finish_reason"] == "stop"
+
+    def test_multiple_completions(self, client, mock_trainer):
+        """Test requesting multiple completions (n > 1)"""
+        # Update mock to return multiple sequences
+        mock_sequences = [
+            SampledSequence(tokens=[10, 11], logprobs=[0.9, 0.8], stop_reason="stop"),
+            SampledSequence(tokens=[12, 13], logprobs=[0.7, 0.6], stop_reason="stop"),
+        ]
+        mock_result = SampleResponse(sequences=mock_sequences)
+        mock_trainer.current_sampling_client.sample_async = AsyncMock(return_value=mock_result)
+
+        request_data = {
+            "prompt": "Hello world",
+            "max_tokens": 50,
+            "temperature": 1.0,
+            "n": 2,
+        }
+
+        response = client.post("/v1/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["choices"]) == 2
+        for i, choice in enumerate(data["choices"]):
+            assert choice["index"] == i
+
+    def test_batch_completions(self, client, mock_trainer):
+        """Test batch completion request with list of prompts"""
+        request_data = {
+            "prompt": ["First prompt", "Second prompt"],
+            "max_tokens": 50,
+            "temperature": 0.8,
+            "n": 1,
+        }
+
+        response = client.post("/v1/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["choices"]) == 2
+
+    def test_with_stop_sequences(self, client, mock_trainer):
+        """Test completion with stop sequences"""
+        request_data = {
+            "prompt": "Count to five:",
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "n": 1,
+            "stop": ["\n", "five"],
+        }
+
+        response = client.post("/v1/completions", json=request_data)
+        assert response.status_code == 200
+
+        call_args = mock_trainer.current_sampling_client.sample_async.call_args
+        sampling_params = call_args.kwargs["sampling_params"]
+        assert sampling_params.stop == ["\n", "five"]
+
+
+class TestChatCompletionsEndpoint:
+    def test_chat_completion(self, client, mock_trainer):
+        """Test basic chat completion"""
+        request_data = {
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "Hello!"},
+            ],
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "n": 1,
+        }
+
+        response = client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "id" in data
+        assert data["id"].startswith("chatcmpl-")
+        assert data["model"] == "meta-llama/Llama-3.1-8B-Instruct"
+        assert len(data["choices"]) == 1
+
+        choice = data["choices"][0]
+        assert choice["message"]["role"] == "assistant"
+        assert choice["message"]["content"] == "Test output"
+        assert choice["finish_reason"] == "stop"
+
+    def test_chat_completion_multiple_samples(self, client, mock_trainer):
+        mock_sequences = [
+            SampledSequence(tokens=[10, 11], logprobs=[0.9, 0.8], stop_reason="stop"),
+            SampledSequence(tokens=[12, 13], logprobs=[0.7, 0.6], stop_reason="stop"),
+            SampledSequence(tokens=[14, 15], logprobs=[0.5, 0.4], stop_reason="stop"),
+        ]
+        mock_result = SampleResponse(sequences=mock_sequences)
+        mock_trainer.current_sampling_client.sample_async = AsyncMock(return_value=mock_result)
+
+        request_data = {
+            "messages": [
+                {"role": "user", "content": "Tell me three jokes"},
+            ],
+            "max_tokens": 200,
+            "temperature": 1.0,
+            "n": 3,
+        }
+
+        response = client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data["choices"]) == 3
+
+    def test_chat_completion_with_stop(self, client, mock_trainer):
+        request_data = {
+            "messages": [
+                {"role": "user", "content": "Count to 10"},
+            ],
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "n": 1,
+            "stop": ["10", "\n\n"],
+        }
+
+        response = client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        call_args = mock_trainer.current_sampling_client.sample_async.call_args
+        sampling_params = call_args.kwargs["sampling_params"]
+        assert sampling_params.stop == ["10", "\n\n"]
+
+
+class TestGenerateEndpoint:
+    def test_generate_single_sample(self, client, mock_trainer):
+        request_data = {
+            "input_ids": [1, 2, 3, 4, 5],
+            "sampling_params": {
+                "n": 1,
+                "max_new_tokens": 100,
+                "temperature": 0.7,
+                "stop": [],
+            },
+        }
+
+        response = client.post("/generate", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "text" in data
+        assert "meta_info" in data
+        assert data["text"] == "Test output"
+
+        meta_info = data["meta_info"]
+        assert meta_info["prompt_tokens"] == 5
+        assert meta_info["completion_tokens"] == 3
+        assert meta_info["finish_reason"] == "stop"
+        assert "output_token_logprobs" in meta_info
+        assert len(meta_info["output_token_logprobs"]) == 3
+
+    def test_generate_multiple_samples(self, client, mock_trainer):
+        mock_sequences = [
+            SampledSequence(tokens=[10, 11], logprobs=[0.9, 0.8], stop_reason="stop"),
+            SampledSequence(tokens=[12, 13], logprobs=[0.7, 0.6], stop_reason="stop"),
+        ]
+        mock_result = SampleResponse(sequences=mock_sequences)
+        mock_trainer.current_sampling_client.sample_async = AsyncMock(return_value=mock_result)
+
+        request_data = {
+            "input_ids": [1, 2, 3],
+            "sampling_params": {
+                "n": 2,
+                "max_new_tokens": 50,
+                "temperature": 1.0,
+            },
+        }
+
+        response = client.post("/generate", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+        for result in data:
+            assert "text" in result
+            assert "meta_info" in result
+            assert result["meta_info"]["prompt_tokens"] == 3
+
+    def test_generate_without_input_ids(self, client):
+        request_data = {
+            "sampling_params": {
+                "max_new_tokens": 100,
+            },
+        }
+
+        response = client.post("/generate", json=request_data)
+        assert response.status_code in [400, 500]
+        assert "input_ids" in response.json()["detail"].lower()
+
+    def test_generate_logprobs_format(self, client, mock_trainer):
+        """Test that logprobs are formatted correctly for SGLang"""
+        mock_sequence = SampledSequence(
+            tokens=[100, 101, 102],
+            logprobs=[-0.5, -0.3, -0.7],
+            stop_reason="stop",
+        )
+        mock_result = SampleResponse(sequences=[mock_sequence])
+        mock_trainer.current_sampling_client.sample_async = AsyncMock(return_value=mock_result)
+
+        def decode_side_effect(tokens, **kwargs):
+            if len(tokens) == 1:
+                return f"token_{tokens[0]}"
+            return "Full output"
+
+        mock_trainer.tokenizer.decode = MagicMock(side_effect=decode_side_effect)
+
+        request_data = {
+            "input_ids": [1, 2],
+            "sampling_params": {
+                "n": 1,
+                "max_new_tokens": 50,
+            },
+        }
+
+        response = client.post("/generate", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        logprobs = data["meta_info"]["output_token_logprobs"]
+
+        assert len(logprobs) == 3
+        assert logprobs[0][0] == -0.5
+        assert logprobs[0][1] == 100
+        assert logprobs[0][2] == "token_100"
+
+
+class TestErrorHandling:
+    def test_completions_without_trainer(self, app_with_trainer):
+        import tinker_atropos.trainer as trainer_module
+
+        original_trainer = trainer_module.trainer
+        trainer_module.trainer = None
+
+        try:
+            client = TestClient(app_with_trainer)
+            response = client.post(
+                "/v1/completions", json={"prompt": "test", "max_tokens": 10, "n": 1}
+            )
+            assert response.status_code == 503
+            assert "Trainer not initialized" in response.json()["detail"]
+        finally:
+            trainer_module.trainer = original_trainer
+
+    def test_chat_completions_without_trainer(self, app_with_trainer):
+        import tinker_atropos.trainer as trainer_module
+
+        original_trainer = trainer_module.trainer
+        trainer_module.trainer = None
+
+        try:
+            client = TestClient(app_with_trainer)
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 10,
+                    "n": 1,
+                },
+            )
+            assert response.status_code == 503
+            assert "Trainer not initialized" in response.json()["detail"]
+        finally:
+            trainer_module.trainer = original_trainer
+
+    def test_generate_without_trainer(self, app_with_trainer):
+        import tinker_atropos.trainer as trainer_module
+
+        original_trainer = trainer_module.trainer
+        trainer_module.trainer = None
+
+        try:
+            client = TestClient(app_with_trainer)
+            response = client.post("/generate", json={"input_ids": [1, 2, 3]})
+            assert response.status_code == 503
+            assert "Trainer not initialized" in response.json()["detail"]
+        finally:
+            trainer_module.trainer = original_trainer

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -188,10 +188,11 @@ class TinkerAtroposTrainer:
                 input_tokens = tokens[:-1]
                 target_tokens = tokens[1:]
 
-                # Shift logprobs to align with targets (tokens[1:])
-                # logprobs[i] corresponds to the probability of tokens[i]
-                # We want logprobs for target_tokens = tokens[1:], so use trajectory_logprobs[1:]
-                all_logprobs = trajectory_logprobs[:-1]  # Remove last logprob to match input length
+                # Shift logprobs to align with target tokens
+                # trajectory_logprobs[i] = logprob of generating tokens[i] given tokens[:i]
+                # For target_tokens = tokens[1:], we need trajectory_logprobs[1:]
+                # This aligns: target[i] gets the logprob from trajectory_logprobs[i+1]
+                all_logprobs = trajectory_logprobs[1:]  # Shift right to align with targets
 
                 # Advantages: use same advantage for all generated tokens, 0.0 for prompt tokens
                 # trajectory_logprobs has 1.0 for prompt tokens, actual values for generated tokens
@@ -224,13 +225,14 @@ class TinkerAtroposTrainer:
 
         if all_reference_logprobs:
             logprob_array = np.array(all_reference_logprobs)
-            logprob_array_nonzero = logprob_array[logprob_array != 0.0]
-            if len(logprob_array_nonzero) > 0:
+            # Filter out both 0.0 and 1.0 (1.0 are placeholder values for prompt tokens)
+            logprob_array_actual = logprob_array[(logprob_array != 0.0) & (logprob_array != 1.0)]
+            if len(logprob_array_actual) > 0:
                 self.logprob_stats = {
-                    "logprobs/mean": float(np.mean(logprob_array_nonzero)),
-                    "logprobs/std": float(np.std(logprob_array_nonzero)),
-                    "logprobs/min": float(np.min(logprob_array_nonzero)),
-                    "logprobs/p50": float(np.percentile(logprob_array_nonzero, 50)),
+                    "logprobs/mean": float(np.mean(logprob_array_actual)),
+                    "logprobs/std": float(np.std(logprob_array_actual)),
+                    "logprobs/min": float(np.min(logprob_array_actual)),
+                    "logprobs/p50": float(np.percentile(logprob_array_actual, 50)),
                 }
             else:
                 self.logprob_stats = {}
@@ -531,7 +533,7 @@ async def generate(request: GenerateRequest):
         sampling_params = request.sampling_params or {}
         n = sampling_params.get("n", 1)
         max_tokens = sampling_params.get("max_new_tokens", 256)
-        temperature = sampling_params.get("temperature", 0.7)
+        temperature = sampling_params.get("temperature", 1.0)
         stop = sampling_params.get("stop", [])
 
         # Generate using Tinker sampling client

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -15,8 +15,11 @@ from transformers import AutoTokenizer
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from tinker_atropos.types import (
+    GenerateRequest,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    CompletionRequest,
+    CompletionResponse,
 )
 
 
@@ -180,13 +183,19 @@ class TinkerAtroposTrainer:
 
                 all_advantages.append(advantage)
 
+                # ManagedServer provides full aligned logprobs (already masked with 1.0 for prompt)
+                # For next-token prediction: input is tokens[:-1], target is tokens[1:]
                 input_tokens = tokens[:-1]
                 target_tokens = tokens[1:]
 
-                ob_len = len(input_tokens) - len(trajectory_logprobs)
+                # Shift logprobs to align with targets (tokens[1:])
+                # logprobs[i] corresponds to the probability of tokens[i]
+                # We want logprobs for target_tokens = tokens[1:], so use trajectory_logprobs[1:]
+                all_logprobs = trajectory_logprobs[:-1]  # Remove last logprob to match input length
 
-                all_logprobs = [0.0] * ob_len + trajectory_logprobs
-                all_advantages_padded = [0.0] * ob_len + [advantage] * len(trajectory_logprobs)
+                # Advantages: use same advantage for all generated tokens, 0.0 for prompt tokens
+                # trajectory_logprobs has 1.0 for prompt tokens, actual values for generated tokens
+                all_advantages_padded = [0.0 if lp == 1.0 else advantage for lp in all_logprobs]
 
                 all_reference_logprobs.extend(all_logprobs)
 
@@ -384,34 +393,102 @@ async def health():
     }
 
 
+@app.post("/v1/completions", response_model=CompletionResponse)
+async def completions(request: CompletionRequest):
+    """
+    OpenAI-compatible completions endpoint.
+    Called by SGLang server wrapper for regular completions (non-chat).
+    """
+    if trainer is None:
+        raise HTTPException(status_code=503, detail="Trainer not initialized")
+
+    try:
+        # Handle single prompt (string) or batch (list of strings)
+        if isinstance(request.prompt, str):
+            prompts = [request.prompt]
+        else:
+            prompts = request.prompt
+
+        all_choices = []
+        choice_index = 0
+
+        for prompt in prompts:
+            # Tokenize prompt
+            prompt_tokens = trainer.tokenizer.encode(prompt, add_special_tokens=False)
+            model_input = ModelInput.from_ints(prompt_tokens)
+
+            # Generate using Tinker sampling client
+            sampling_params = SamplingParams(
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+                stop=request.stop if request.stop else [],
+            )
+
+            result = await trainer.current_sampling_client.sample_async(
+                prompt=model_input,
+                sampling_params=sampling_params,
+                num_samples=request.n,
+            )
+
+            # Format choices
+            for sequence in result.sequences:
+                output_text = trainer.tokenizer.decode(sequence.tokens, skip_special_tokens=True)
+                all_choices.append(
+                    {
+                        "text": output_text,
+                        "index": choice_index,
+                        "finish_reason": "stop",
+                    }
+                )
+                choice_index += 1
+
+        return CompletionResponse(
+            id=f"cmpl-{random.randint(0, 999999)}",
+            choices=all_choices,
+            created=int(time.time()),
+            model=trainer.base_model,
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Completion failed: {str(e)}")
+
+
 @app.post("/v1/chat/completions", response_model=ChatCompletionResponse)
 async def chat_completions(request: ChatCompletionRequest):
+    """
+    OpenAI-compatible chat completions endpoint.
+    Called by SGLang server wrapper for regular chat completions.
+    """
     if trainer is None:
         raise HTTPException(status_code=503, detail="Trainer not initialized")
 
     try:
         messages_dict = [{"role": msg.role, "content": msg.content} for msg in request.messages]
 
-        (
-            prompt_tokens,
-            output_tokens_list,
-            output_logprobs_list,
-            finish_reasons_list,
-        ) = await trainer.generate_with_logprobs(
-            messages=messages_dict,
-            n=request.n,
+        # Apply chat template and tokenize
+        prompt_text = trainer.tokenizer.apply_chat_template(
+            messages_dict, tokenize=False, add_generation_prompt=True
+        )
+        prompt_tokens = trainer.tokenizer.encode(prompt_text, add_special_tokens=False)
+        model_input = ModelInput.from_ints(prompt_tokens)
+
+        # Generate using Tinker sampling client
+        sampling_params = SamplingParams(
             max_tokens=request.max_tokens,
             temperature=request.temperature,
-            stop=request.stop,
+            stop=request.stop if request.stop else [],
         )
 
-        choices = []
-        for i, (output_tokens, logprobs, finish_reason) in enumerate(
-            zip(output_tokens_list, output_logprobs_list, finish_reasons_list)
-        ):
-            full_tokens = prompt_tokens + output_tokens
-            output_text = trainer.tokenizer.decode(output_tokens, skip_special_tokens=True)
+        result = await trainer.current_sampling_client.sample_async(
+            prompt=model_input,
+            sampling_params=sampling_params,
+            num_samples=request.n,
+        )
 
+        # Format as OpenAI response
+        choices = []
+        for i, sequence in enumerate(result.sequences):
+            output_text = trainer.tokenizer.decode(sequence.tokens, skip_special_tokens=True)
             choices.append(
                 {
                     "message": {
@@ -419,9 +496,7 @@ async def chat_completions(request: ChatCompletionRequest):
                         "content": output_text,
                     },
                     "index": i,
-                    "finish_reason": finish_reason,
-                    "logprobs": logprobs,
-                    "tokens": full_tokens,
+                    "finish_reason": "stop",
                 }
             )
 
@@ -434,6 +509,100 @@ async def chat_completions(request: ChatCompletionRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Chat completion failed: {str(e)}")
+
+
+@app.post("/generate")
+async def generate(request: GenerateRequest):
+    """
+    SGLang-compatible /generate endpoint.
+    Called by ManagedServer with tokenized input_ids.
+    """
+    if trainer is None:
+        raise HTTPException(status_code=503, detail="Trainer not initialized")
+
+    try:
+        # Extract input_ids (ManagedServer sends tokenized input)
+        if request.input_ids is None:
+            raise HTTPException(status_code=400, detail="input_ids is required")
+
+        prompt_tokens = request.input_ids
+
+        # Extract sampling params
+        sampling_params = request.sampling_params or {}
+        n = sampling_params.get("n", 1)
+        max_tokens = sampling_params.get("max_new_tokens", 256)
+        temperature = sampling_params.get("temperature", 0.7)
+        stop = sampling_params.get("stop", [])
+
+        # Generate using Tinker sampling client
+        model_input = ModelInput.from_ints(prompt_tokens)
+        tinker_sampling_params = SamplingParams(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stop=stop if isinstance(stop, list) else [stop],
+        )
+
+        result = await trainer.current_sampling_client.sample_async(
+            prompt=model_input,
+            sampling_params=tinker_sampling_params,
+            num_samples=n,
+        )
+
+        # Process results - format for SGLang compatibility
+        # SGLang wrapper expects: if not isinstance(results, list): results = [results]
+        # So for n=1, return single dict. For n>1, return list of dicts.
+
+        if n == 1:
+            sequence = result.sequences[0]
+            output_tokens = sequence.tokens
+            output_logprobs = sequence.logprobs if sequence.logprobs else []
+            output_text = trainer.tokenizer.decode(output_tokens, skip_special_tokens=True)
+
+            # Format logprobs as SGLang expects: [(logprob, token_id, text), ...]
+            output_token_logprobs = []
+            for token_id, logprob in zip(output_tokens, output_logprobs):
+                token_text = trainer.tokenizer.decode([token_id])
+                output_token_logprobs.append((logprob, token_id, token_text))
+
+            return {
+                "text": output_text,
+                "meta_info": {
+                    "prompt_tokens": len(prompt_tokens),
+                    "completion_tokens": len(output_tokens),
+                    "finish_reason": "stop",
+                    "output_token_logprobs": output_token_logprobs,
+                },
+            }
+        else:
+            # Multiple completions - return list of dicts
+            results = []
+            for sequence in result.sequences:
+                output_tokens = sequence.tokens
+                output_logprobs = sequence.logprobs if sequence.logprobs else []
+                output_text = trainer.tokenizer.decode(output_tokens, skip_special_tokens=True)
+
+                # Format logprobs as SGLang expects
+                output_token_logprobs = []
+                for token_id, logprob in zip(output_tokens, output_logprobs):
+                    token_text = trainer.tokenizer.decode([token_id])
+                    output_token_logprobs.append((logprob, token_id, token_text))
+
+                results.append(
+                    {
+                        "text": output_text,
+                        "meta_info": {
+                            "prompt_tokens": len(prompt_tokens),
+                            "completion_tokens": len(output_tokens),
+                            "finish_reason": "stop",
+                            "output_token_logprobs": output_token_logprobs,
+                        },
+                    }
+                )
+
+            return results
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Generation failed: {str(e)}")
 
 
 def run_fastapi_server():

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -107,43 +107,6 @@ class TinkerAtroposTrainer:
         result = response.json()
         return result.get("uuid")
 
-    async def generate_with_logprobs(
-        self,
-        messages: List[Dict[str, str]],
-        n: int = 1,
-        max_tokens: int = 256,
-        temperature: float = 0.7,
-        stop: List[str] = None,
-    ) -> tuple[list, list, list, list]:
-        prompt_text = self.tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
-        prompt_tokens = self.tokenizer.encode(prompt_text, add_special_tokens=False)
-        model_input = ModelInput.from_ints(prompt_tokens)
-
-        sampling_params = SamplingParams(
-            max_tokens=max_tokens,
-            temperature=temperature,
-            stop=stop if stop else [],
-        )
-
-        result = await self.current_sampling_client.sample_async(
-            prompt=model_input,
-            sampling_params=sampling_params,
-            num_samples=n,
-        )
-
-        output_tokens_list = []
-        output_logprobs_list = []
-        finish_reasons_list = []
-
-        for sequence in result.sequences:
-            output_tokens_list.append(sequence.tokens)
-            output_logprobs_list.append(sequence.logprobs if sequence.logprobs else [])
-            finish_reasons_list.append("stop")  # TODO: get actual finish reason
-
-        return prompt_tokens, output_tokens_list, output_logprobs_list, finish_reasons_list
-
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=15))
     def get_batch(self):
         data = requests.get(f"{self.atropos_api_url}/batch", timeout=10).json()
@@ -183,19 +146,11 @@ class TinkerAtroposTrainer:
 
                 all_advantages.append(advantage)
 
-                # ManagedServer provides full aligned logprobs (already masked with 1.0 for prompt)
-                # For next-token prediction: input is tokens[:-1], target is tokens[1:]
                 input_tokens = tokens[:-1]
                 target_tokens = tokens[1:]
 
-                # Shift logprobs to align with target tokens
-                # trajectory_logprobs[i] = logprob of generating tokens[i] given tokens[:i]
-                # For target_tokens = tokens[1:], we need trajectory_logprobs[1:]
-                # This aligns: target[i] gets the logprob from trajectory_logprobs[i+1]
                 all_logprobs = trajectory_logprobs[1:]  # Shift right to align with targets
 
-                # Advantages: use same advantage for all generated tokens, 0.0 for prompt tokens
-                # trajectory_logprobs has 1.0 for prompt tokens, actual values for generated tokens
                 all_advantages_padded = [0.0 if lp == 1.0 else advantage for lp in all_logprobs]
 
                 all_reference_logprobs.extend(all_logprobs)
@@ -550,17 +505,12 @@ async def generate(request: GenerateRequest):
             num_samples=n,
         )
 
-        # Process results - format for SGLang compatibility
-        # SGLang wrapper expects: if not isinstance(results, list): results = [results]
-        # So for n=1, return single dict. For n>1, return list of dicts.
-
         if n == 1:
             sequence = result.sequences[0]
             output_tokens = sequence.tokens
             output_logprobs = sequence.logprobs if sequence.logprobs else []
             output_text = trainer.tokenizer.decode(output_tokens, skip_special_tokens=True)
 
-            # Format logprobs as SGLang expects: [(logprob, token_id, text), ...]
             output_token_logprobs = []
             for token_id, logprob in zip(output_tokens, output_logprobs):
                 token_text = trainer.tokenizer.decode([token_id])

--- a/tinker_atropos/types.py
+++ b/tinker_atropos/types.py
@@ -45,3 +45,25 @@ class ChatCompletionResponse(BaseModel):
     choices: List[Dict[str, Any]]
     created: int
     model: str
+
+
+# Request format for /generate endpoint (SGLang compatible).
+class GenerateRequest(BaseModel):
+    text: str | List[str] | None = None  # Input text or list of texts
+    input_ids: List[int] | List[List[int]] | None = None  # Input token IDs (alternative to text)
+    sampling_params: Dict[
+        str, Any
+    ] | None = None  # Sampling parameters: temperature, top_p, max_new_tokens, n, etc.
+    return_logprob: bool = True  # Whether to return log probabilities
+    top_logprobs_num: int = 0  # Number of top logprobs to return per token
+    return_text_in_logprobs: bool = False  # Whether to return text in logprobs
+    logprob_start_len: int | None = None  # Start position for logprobs (for prompt)
+    stream: bool = False  # Whether to stream responses
+
+
+# Response format for /generate endpoint (SGLang compatible).
+class GenerateResponse(BaseModel):
+    text: str | List[str]  # Generated text(s)
+    meta_info: Dict[
+        str, Any
+    ]  # Contains: output_token_logprobs, finish_reason, prompt_tokens, completion_tokens


### PR DESCRIPTION
We had a PR merged into Atropos to use the ManagedServer object with SGLang, and wanted to reflect the implementation here to match this. 

Reference PR: https://github.com/NousResearch/atropos/pull/264

This PR introduces the use of ManagedServer along with the `/generate` endpoint exposed from the combined trainer/inference file.