### PR TITLE
Adding config YAML files and top level trainer launcher

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,37 @@
+# Default configuration for Tinker-Atropos training
+# This file demonstrates all available configuration options
+
+# Model configuration
+base_model: "meta-llama/Llama-3.1-8B-Instruct"
+lora_rank: 32
+learning_rate: 0.00004
+
+# Training configuration
+num_steps: 50
+batch_size: 128
+group_size: 16
+max_token_env_length: 256
+max_token_trainer_length: 2048
+max_num_workers: 24
+max_batches_offpolicy: 3
+
+# Weights & Biases configuration
+use_wandb: true
+wandb_project: "atropos-tinker"
+wandb_group: null  # Will be auto-generated if not specified
+wandb_run_name: "atropos-tinker-run"
+
+# API endpoints
+atropos_api_url: "http://localhost:8000"
+inference_api_url: "http://localhost:8001"
+
+# Checkpoint configuration (needed for Atropos BaseEnvConfig - not used)
+checkpoint_dir: "./temp/"
+save_checkpoint_interval: 0
+
+# Evaluation configuration
+steps_per_eval: 100
+num_requests_for_eval: 256
+
+# Training options
+ensure_scores_not_the_same: false

--- a/configs/quick_test.yaml
+++ b/configs/quick_test.yaml
@@ -1,0 +1,28 @@
+# Quick test configuration with minimal resources
+# Useful for testing the setup and debugging
+
+base_model: "meta-llama/Llama-3.1-8B-Instruct"
+lora_rank: 16
+learning_rate: 0.0001
+
+num_steps: 10
+batch_size: 32
+group_size: 4
+max_token_env_length: 128
+max_token_trainer_length: 512
+max_num_workers: 16
+max_batches_offpolicy: 2
+
+use_wandb: false
+wandb_project: "atropos-tinker-test"
+
+atropos_api_url: "http://localhost:8000"
+inference_api_url: "http://localhost:8001"
+
+checkpoint_dir: "./temp/"
+save_checkpoint_interval: 0
+
+steps_per_eval: 10
+num_requests_for_eval: 64
+
+ensure_scores_not_the_same: true

--- a/configs/usage.md
+++ b/configs/usage.md
@@ -20,21 +20,9 @@ Minimal resource configuration optimized for rapid testing and debugging.
 
 **Use case**: Local testing, debugging, CI/CD pipelines
 
-### `production.yaml`
-Large-scale configuration for production training runs.
-
-**Features**:
-- Higher LoRA rank for better model capacity
-- Larger batch sizes and token lengths
-- More parallel workers
-- Checkpointing enabled
-- Full wandb logging
-
-**Use case**: Full-scale training runs, production deployments
-
 ## Configuration Parameters
 
-### Model Configuration
+### Tinker Model Configuration
 - `base_model`: HuggingFace model identifier (default: "meta-llama/Llama-3.1-8B-Instruct")
 - `lora_rank`: Rank of LoRA adapters (default: 32)
 - `learning_rate`: Optimizer learning rate (default: 0.00004)
@@ -45,7 +33,7 @@ Large-scale configuration for production training runs.
 - `group_size`: Number of rollouts generated per question (default: 16)
 - `max_token_env_length`: Maximum tokens for environment rollouts (default: 256)
 - `max_token_trainer_length`: Maximum tokens for trainer processing (default: 2048)
-- `max_num_workers`: Maximum parallel workers for rollout generation (default: 24)
+- `max_num_workers`: Maximum parallel workers for rollout generation (calculated as (batch_size * num_offpolicy // group_size)) (default: 24)
 - `max_batches_offpolicy`: Maximum batches before data considered stale (default: 3)
 
 ### Weights & Biases Configuration
@@ -58,10 +46,6 @@ Large-scale configuration for production training runs.
 ### API Endpoints
 - `atropos_api_url`: URL for Atropos rollout server (default: "http://localhost:8000")
 - `inference_api_url`: URL for unified trainer inference endpoint (default: "http://localhost:8001")
-
-### Checkpointing
-- `checkpoint_dir`: Directory for saving model checkpoints (default: "./temp/")
-- `save_checkpoint_interval`: Steps between checkpoints, 0 to disable (default: 0)
 
 ### Evaluation
 - `steps_per_eval`: Steps between evaluation runs (default: 100)
@@ -100,7 +84,7 @@ python launch_training.py --config configs/quick_test.yaml \
 from tinker_atropos.config import TinkerAtroposConfig
 
 # Load from YAML
-config = TinkerAtroposConfig.from_yaml("configs/production.yaml")
+config = TinkerAtroposConfig.from_yaml("configs/quick_test.yaml")
 
 # Modify programmatically
 config.num_steps = 500
@@ -173,7 +157,6 @@ python launch_training.py
 
 - Start with `quick_test.yaml` to validate your setup
 - Use `default.yaml` as a template for custom configs
-- Enable wandb logging for production runs to track metrics
-- Adjust `max_num_workers` based on your available compute
-- Set `save_checkpoint_interval > 0` for long training runs
+- Enable wandb logging for runs to track metrics
+- Adjust `max_num_workers` based on your batch size, group size, and max_batches_offpolicy value
 - Use CLI overrides for one-off experiments without creating new config files

--- a/configs/usage.md
+++ b/configs/usage.md
@@ -1,0 +1,179 @@
+# Tinker-Atropos Configuration Files
+
+This directory contains YAML configuration files for the Tinker-Atropos training system. Config files provide an easy way to manage different training environments and can be combined with CLI overrides.
+
+## Available Configurations
+
+### `default.yaml`
+Standard configuration suitable for typical training runs. This config demonstrates all available options with reasonable defaults.
+
+**Use case**: Regular training experiments with moderate resources
+
+### `quick_test.yaml`
+Minimal resource configuration optimized for rapid testing and debugging.
+
+**Features**:
+- Reduced batch size and token lengths
+- Fewer workers and shorter training steps
+- Wandb disabled by default
+- Ideal for validating setup and code changes
+
+**Use case**: Local testing, debugging, CI/CD pipelines
+
+### `production.yaml`
+Large-scale configuration for production training runs.
+
+**Features**:
+- Higher LoRA rank for better model capacity
+- Larger batch sizes and token lengths
+- More parallel workers
+- Checkpointing enabled
+- Full wandb logging
+
+**Use case**: Full-scale training runs, production deployments
+
+## Configuration Parameters
+
+### Model Configuration
+- `base_model`: HuggingFace model identifier (default: "meta-llama/Llama-3.1-8B-Instruct")
+- `lora_rank`: Rank of LoRA adapters (default: 32)
+- `learning_rate`: Optimizer learning rate (default: 0.00004)
+
+### Training Configuration
+- `num_steps`: Total number of training steps (default: 100)
+- `batch_size`: Number of datums per training batch (default: 128)
+- `group_size`: Number of rollouts generated per question (default: 16)
+- `max_token_env_length`: Maximum tokens for environment rollouts (default: 256)
+- `max_token_trainer_length`: Maximum tokens for trainer processing (default: 2048)
+- `max_num_workers`: Maximum parallel workers for rollout generation (default: 24)
+- `max_batches_offpolicy`: Maximum batches before data considered stale (default: 3)
+
+### Weights & Biases Configuration
+- `use_wandb`: Enable/disable wandb logging (default: true)
+- `wandb_project`: Wandb project name (default: "atropos-tinker")
+- `wandb_group`: Wandb group name for organizing runs (default: null, auto-generated)
+- `wandb_run_name`: Base name for wandb runs (default: "atropos-tinker-run")
+- `wandb_run_suffix`: Random suffix for unique run names (auto-generated)
+
+### API Endpoints
+- `atropos_api_url`: URL for Atropos rollout server (default: "http://localhost:8000")
+- `inference_api_url`: URL for unified trainer inference endpoint (default: "http://localhost:8001")
+
+### Checkpointing
+- `checkpoint_dir`: Directory for saving model checkpoints (default: "./temp/")
+- `save_checkpoint_interval`: Steps between checkpoints, 0 to disable (default: 0)
+
+### Evaluation
+- `steps_per_eval`: Steps between evaluation runs (default: 100)
+- `num_requests_for_eval`: Number of requests per evaluation (default: 256)
+
+### Debug Options
+- `ensure_scores_not_the_same`: Validate that scores differ within groups (default: false)
+
+## Usage Examples
+
+### Basic Usage
+```bash
+# Use default config
+python launch_training.py --config configs/default.yaml
+
+# Use quick test config
+python launch_training.py --config configs/quick_test.yaml
+```
+
+### With CLI Overrides
+```bash
+# Override specific parameters
+python launch_training.py --config configs/default.yaml \
+    --num-steps 50 \
+    --batch-size 64 \
+    --no-wandb
+
+# Change model and adjust hyperparameters
+python launch_training.py --config configs/quick_test.yaml \
+    --base-model "meta-llama/Llama-3.2-1B-Instruct" \
+    --learning-rate 0.0001
+```
+
+### Programmatic Usage
+```python
+from tinker_atropos.config import TinkerAtroposConfig
+
+# Load from YAML
+config = TinkerAtroposConfig.from_yaml("configs/production.yaml")
+
+# Modify programmatically
+config.num_steps = 500
+config.use_wandb = True
+
+# Use with trainer
+from tinker_atropos.trainer import TinkerAtroposTrainer
+trainer = TinkerAtroposTrainer(config=config)
+```
+
+## Creating Custom Configs
+
+To create a new configuration:
+
+1. Copy an existing config file as a template
+2. Modify parameters as needed
+3. Save with a descriptive name (e.g., `configs/my_experiment.yaml`)
+4. Run with: `python launch_training.py --config configs/my_experiment.yaml`
+
+### Example Custom Config
+
+```yaml
+# configs/my_custom_config.yaml
+base_model: "meta-llama/Llama-3.2-3B-Instruct"
+lora_rank: 48
+learning_rate: 0.00005
+
+num_steps: 200
+batch_size: 96
+group_size: 24
+
+use_wandb: true
+wandb_project: "my-custom-experiment"
+wandb_run_name: "custom-run"
+
+checkpoint_dir: "./my_checkpoints/"
+save_checkpoint_interval: 50
+```
+
+## Configuration Priority
+
+When parameters are specified in multiple places, the priority order is:
+
+1. **CLI arguments** (highest priority)
+2. **YAML config file**
+3. **Environment variables** (with `TINKER_ATROPOS_` prefix)
+4. **Default values** (lowest priority)
+
+Example:
+```bash
+# YAML has num_steps: 100
+# CLI overrides to 50
+python launch_training.py --config configs/default.yaml --num-steps 50
+# Result: num_steps = 50
+```
+
+## Environment Variables
+
+All config parameters can be set via environment variables with the `TINKER_ATROPOS_` prefix:
+
+```bash
+export TINKER_ATROPOS_BASE_MODEL="meta-llama/Llama-3.2-1B-Instruct"
+export TINKER_ATROPOS_NUM_STEPS=200
+export TINKER_ATROPOS_USE_WANDB=true
+
+python launch_training.py
+```
+
+## Tips
+
+- Start with `quick_test.yaml` to validate your setup
+- Use `default.yaml` as a template for custom configs
+- Enable wandb logging for production runs to track metrics
+- Adjust `max_num_workers` based on your available compute
+- Set `save_checkpoint_interval > 0` for long training runs
+- Use CLI overrides for one-off experiments without creating new config files

--- a/launch_training.py
+++ b/launch_training.py
@@ -1,0 +1,154 @@
+import argparse
+import asyncio
+import sys
+
+from tinker_atropos.config import TinkerAtroposConfig
+import tinker_atropos.trainer as trainer_module
+from tinker_atropos.trainer import TinkerAtroposTrainer
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Launch Tinker-Atropos training with YAML configuration",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to YAML config file (e.g., configs/default.yaml)",
+    )
+
+    # Allow overriding specific config parameters via CLI
+    parser.add_argument("--base-model", type=str, help="Override base model")
+    parser.add_argument("--lora-rank", type=int, help="Override LoRA rank")
+    parser.add_argument("--learning-rate", type=float, help="Override learning rate")
+    parser.add_argument("--num-steps", type=int, help="Override number of training steps")
+    parser.add_argument("--batch-size", type=int, help="Override batch size")
+    parser.add_argument("--group-size", type=int, help="Override group size")
+    parser.add_argument("--wandb-project", type=str, help="Override wandb project name")
+    parser.add_argument("--wandb-group", type=str, help="Override wandb group name")
+    parser.add_argument(
+        "--no-wandb",
+        action="store_true",
+        help="Disable wandb logging",
+    )
+
+    return parser.parse_args()
+
+
+def load_config(args) -> TinkerAtroposConfig:
+    """
+    Load configuration from YAML file and apply CLI overrides.
+    """
+    # Start with YAML config if provided, otherwise use defaults
+    if args.config:
+        print(f"Loading config from: {args.config}")
+        config = TinkerAtroposConfig.from_yaml(args.config)
+    else:
+        print("Using default configuration")
+        config = TinkerAtroposConfig()
+
+    # Apply CLI overrides
+    overrides = {}
+    if args.base_model:
+        overrides["base_model"] = args.base_model
+    if args.lora_rank is not None:
+        overrides["lora_rank"] = args.lora_rank
+    if args.learning_rate is not None:
+        overrides["learning_rate"] = args.learning_rate
+    if args.num_steps is not None:
+        overrides["num_steps"] = args.num_steps
+    if args.batch_size is not None:
+        overrides["batch_size"] = args.batch_size
+    if args.group_size is not None:
+        overrides["group_size"] = args.group_size
+    if args.wandb_project:
+        overrides["wandb_project"] = args.wandb_project
+    if args.wandb_group:
+        overrides["wandb_group"] = args.wandb_group
+    if args.no_wandb:
+        overrides["use_wandb"] = False
+
+    # Create new config with overrides if any were provided
+    if overrides:
+        print(f"Applying CLI overrides: {overrides}")
+        config_dict = config.to_dict()
+        config_dict.update(overrides)
+        config = TinkerAtroposConfig(**config_dict)
+
+    return config
+
+
+async def main():
+    """Main entry point for launching training."""
+    args = parse_args()
+
+    # Load configuration
+    try:
+        config = load_config(args)
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    # Display configuration
+    print("\n" + "=" * 80)
+    print("Training Configuration:")
+    print("=" * 80)
+    print(f"Base Model: {config.base_model}")
+    print(f"LoRA Rank: {config.lora_rank}")
+    print(f"Learning Rate: {config.learning_rate}")
+    print(f"Training Steps: {config.num_steps}")
+    print(f"Batch Size: {config.batch_size}")
+    print(f"Group Size: {config.group_size}")
+    print(f"Max Token Length (Env): {config.max_token_env_length}")
+    print(f"Max Token Length (Trainer): {config.max_token_trainer_length}")
+    print(f"Max Workers: {config.max_num_workers}")
+    print(f"Wandb Enabled: {config.use_wandb}")
+    if config.use_wandb:
+        print(f"  Project: {config.wandb_project}")
+        print(f"  Group: {config.wandb_group or '(auto-generated)'}")
+        print(f"  Run Name: {config.wandb_run_name}-{config.wandb_run_suffix}")
+    print(f"Atropos API URL: {config.atropos_api_url}")
+    print(f"Inference API URL: {config.inference_api_url}")
+    print("=" * 80 + "\n")
+
+    # Initialize trainer
+    print("Initializing Tinker-Atropos Trainer...")
+    trainer = TinkerAtroposTrainer(config=config)
+
+    # Set the global trainer variable so FastAPI endpoints can access it
+    trainer_module.trainer = trainer
+
+    # Start FastAPI inference server in background thread
+    from tinker_atropos.trainer import run_fastapi_server
+    import threading
+
+    print("Starting FastAPI inference server on port 8001...")
+    server_thread = threading.Thread(target=run_fastapi_server, daemon=True)
+    server_thread.start()
+
+    print("Waiting for FastAPI server to start...")
+    await asyncio.sleep(3)
+
+    # Run training
+    try:
+        await trainer.run()
+        print("\n" + "=" * 80)
+        print("Training completed successfully!")
+        print("=" * 80)
+    except KeyboardInterrupt:
+        print("\n\nTraining interrupted by user.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n\nError during training: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/launch_training.py
+++ b/launch_training.py
@@ -43,7 +43,7 @@ def load_config(args) -> TinkerAtroposConfig:
     """
     Load configuration from YAML file and apply CLI overrides.
     """
-    # Start with YAML config if provided, otherwise use defaults
+
     if args.config:
         print(f"Loading config from: {args.config}")
         config = TinkerAtroposConfig.from_yaml(args.config)

--- a/tinker_atropos/config.py
+++ b/tinker_atropos/config.py
@@ -1,7 +1,9 @@
 import random
 import string
+from pathlib import Path
 from typing import Optional
 
+import yaml
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -11,6 +13,7 @@ def generate_run_suffix() -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
 
 
+# Values here are set as the default values when not using a config YAML
 class TinkerAtroposConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="TINKER_ATROPOS_",
@@ -57,3 +60,17 @@ class TinkerAtroposConfig(BaseSettings):
 
     def to_dict(self):
         return self.model_dump()
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str | Path) -> "TinkerAtroposConfig":
+        """
+        Load configuration from a YAML file.
+        """
+        yaml_path = Path(yaml_path)
+        if not yaml_path.exists():
+            raise FileNotFoundError(f"Config file not found: {yaml_path}")
+
+        with open(yaml_path, "r") as f:
+            yaml_data = yaml.safe_load(f)
+
+        return cls(**yaml_data)


### PR DESCRIPTION
This PR adds 2 example YAML files for configuration: `default.yaml` and `quick_test.yaml`

In addition, the base `config.py` file is updated to load values into the Pydantic model from these files.

Lastly added a top-level trainer script to call from root, e.g. `python launch_training.py --configs/default.yaml`