### PR TITLE
Bugfixes for generation response types and weight downloading

### DIFF
--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -16,6 +16,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from tinker_atropos.types import (
     GenerateRequest,
+    GenerateResponse,
     ChatCompletionRequest,
     ChatCompletionResponse,
     CompletionRequest,
@@ -372,6 +373,10 @@ class TinkerAtroposTrainer:
         print("Training complete!")
         print("=" * 60 + "\n")
 
+        print(
+            f"Final weights are available here: tinker://{str(self.training_client.model_id)}/sampler_weights/final"
+        )
+
 
 trainer: TinkerAtroposTrainer | None = None
 
@@ -446,6 +451,8 @@ async def completions(request: CompletionRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Completion failed: {str(e)}")
+
+
 @app.get("/wandb_info")
 async def wandb_info():
     if trainer is None:
@@ -515,11 +522,12 @@ async def chat_completions(request: ChatCompletionRequest):
         raise HTTPException(status_code=500, detail=f"Chat completion failed: {str(e)}")
 
 
-@app.post("/generate")
+@app.post("/generate", response_model=GenerateResponse | List[GenerateResponse])
 async def generate(request: GenerateRequest):
     """
     SGLang-compatible /generate endpoint.
     Called by ManagedServer with tokenized input_ids.
+    Returns GenerateResponse for single completion (n=1) or List[GenerateResponse] for multiple (n>1).
     """
     if trainer is None:
         raise HTTPException(status_code=503, detail="Trainer not initialized")
@@ -563,17 +571,17 @@ async def generate(request: GenerateRequest):
                 token_text = trainer.tokenizer.decode([token_id])
                 output_token_logprobs.append((logprob, token_id, token_text))
 
-            return {
-                "text": output_text,
-                "meta_info": {
+            return GenerateResponse(
+                text=output_text,
+                meta_info={
                     "prompt_tokens": len(prompt_tokens),
                     "completion_tokens": len(output_tokens),
                     "finish_reason": "stop",
                     "output_token_logprobs": output_token_logprobs,
                 },
-            }
+            )
         else:
-            # Multiple completions - return list of dicts
+            # Multiple completions - return list of GenerateResponse objects
             results = []
             for sequence in result.sequences:
                 output_tokens = sequence.tokens
@@ -587,15 +595,15 @@ async def generate(request: GenerateRequest):
                     output_token_logprobs.append((logprob, token_id, token_text))
 
                 results.append(
-                    {
-                        "text": output_text,
-                        "meta_info": {
+                    GenerateResponse(
+                        text=output_text,
+                        meta_info={
                             "prompt_tokens": len(prompt_tokens),
                             "completion_tokens": len(output_tokens),
                             "finish_reason": "stop",
                             "output_token_logprobs": output_token_logprobs,
                         },
-                    }
+                    )
                 )
 
             return results

--- a/tinker_atropos/types.py
+++ b/tinker_atropos/types.py
@@ -55,7 +55,9 @@ class GenerateRequest(BaseModel):
     stream: bool = False  # Whether to stream responses
 
 
-# Response format for /generate endpoint (SGLang compatible). - unused currently
+# Response format for /generate endpoint (SGLang compatible).
+# For single completion (n=1): returns one GenerateResponse
+# For multiple completions (n>1): returns List[GenerateResponse]
 class GenerateResponse(BaseModel):
     text: str | List[str]  # Generated text(s)
     meta_info: Dict[

--- a/tinker_atropos/utils/download_weights.py
+++ b/tinker_atropos/utils/download_weights.py
@@ -1,0 +1,15 @@
+import tinker
+import urllib.request
+
+# Replace this with your weights path output at the end of the training run
+# <unique_id> is the Training Run ID in Tinker console
+TINKER_PATH = "tinker://<unique_id>/sampler_weights/final"
+
+OUTPUT_FILENAME = "archive.tar"
+
+sc = tinker.ServiceClient()
+rc = sc.create_rest_client()
+future = rc.get_checkpoint_archive_url_from_tinker_path(TINKER_PATH)
+checkpoint_archive_url_response = future.result()
+
+urllib.request.urlretrieve(checkpoint_archive_url_response.url, OUTPUT_FILENAME)

--- a/tinker_atropos/utils/download_weights.py
+++ b/tinker_atropos/utils/download_weights.py
@@ -7,9 +7,13 @@ TINKER_PATH = "tinker://<unique_id>/sampler_weights/final"
 
 OUTPUT_FILENAME = "archive.tar"
 
+print("Downloading weights from Tinker...")
+
 sc = tinker.ServiceClient()
 rc = sc.create_rest_client()
 future = rc.get_checkpoint_archive_url_from_tinker_path(TINKER_PATH)
 checkpoint_archive_url_response = future.result()
 
 urllib.request.urlretrieve(checkpoint_archive_url_response.url, OUTPUT_FILENAME)
+
+print(f"Finished! Weights are available at {OUTPUT_FILENAME}")


### PR DESCRIPTION
This PR does the following two things:
1. Changes the response type of `/generate` from the inference part of the trainer client to use the `GenerateResponse` type for `types.py`
2. Adds outputs for a weights path at the end of training, plus provides a utility file to download these weights.