### PR TITLE
Repo Cleanup + README Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tinker-atropos
 
-Atropos integration with Thinking Machines Tinker API (https://thinkingmachines.ai/tinker/)
+Atropos integration with Thinking Machines Tinker API (https://thinkingmachines.ai/tinker/). Train models with your Atropos environments from your CPU, without having to worry about underlying compute management or implementation.
 
 ## Installation
 
@@ -26,7 +26,7 @@ python launch_training.py --config configs/quick_test.yaml
 python tinker_atropos/environments/gsm8k_tinker.py serve
 ```
 
-This runs a 10-step training example with Llama-3.1-8B on the GSM8k environment.
+This runs a 10-step training example with Llama-3.1-1B on the GSM8k environment.
 
 ## Integration with Atropos Environments
 
@@ -44,6 +44,36 @@ async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
     state = managed.get_state()
     nodes = state["nodes"]
 ```
+
+### How To Implement With An Existing Atropos Environment
+
+1. The `TinkerAtroposConfig` should be loaded in the environment (inside `config.init`), pointing to your desired `config.yaml`, like so:
+
+```
+config = TinkerAtroposConfig.from_yaml("configs/default.yaml")
+```
+
+2. The `BaseEnvConfig`, or whatever is overridden for configuration there, should be set up to use these values, like so:
+
+```
+env_config = BaseEnvConfig(
+    tokenizer_name=config.base_model,
+    group_size=config.group_size,
+    use_wandb=config.use_wandb,
+    rollout_server_url=config.atropos_api_url,
+    total_steps=config.num_steps,
+    batch_size=config.batch_size,
+    steps_per_eval=config.steps_per_eval,
+    max_token_length=config.max_token_env_length,
+    max_num_workers=config.max_num_workers,
+    max_batches_offpolicy=config.max_batches_offpolicy,
+    wandb_name=f"{config.wandb_run_name}-env",
+    ensure_scores_not_the_same=config.ensure_scores_not_the_same,
+)
+```
+
+3. As long as your environment uses the `self.server.managed_server` pattern for inference requests like above, this should *just work*.
+
 
 ## Downloading Weights
 
@@ -91,7 +121,6 @@ python launch_training.py --config configs/default.yaml --num-steps 100 --no-wan
 - **Training**: `num_steps`, `batch_size`, `group_size`, `max_token_env_length`, `max_token_trainer_length`
 - **Wandb**: `use_wandb`, `wandb_project`, `wandb_group`, `wandb_run_name`
 - **APIs**: `atropos_api_url`, `inference_api_url`
-- **Checkpointing**: `checkpoint_dir`, `save_checkpoint_interval`
 
 See `configs/` for complete parameter lists.
 
@@ -117,6 +146,9 @@ trainer = TinkerAtroposTrainer(config=config)
 python -m pytest tinker_atropos/tests/ -v
 ```
 
+## Cost
+
+The Tinker Rate Card and available models are listed here: https://tinker-console.thinkingmachines.ai/rate-card
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tinker-atropos
 
-Atropos integration with Thinking Machines Tinker API (https://thinkingmachines.ai/tinker/). Train models with your Atropos environments from your CPU, without having to worry about underlying compute management or implementation.
+An integration layer connecting Atropos with the Thinking Machines Tinker API (https://thinkingmachines.ai/tinker/). This package enables seamless model training with Atropos environments from your local machine, abstracting away compute management and infrastructure concerns.
 
 ## Installation
 
@@ -30,7 +30,7 @@ This runs a 10-step training example with Llama-3.1-1B on the GSM8k environment.
 
 ## Integration with Atropos Environments
 
-Atropos environments using the following pattern for inference can integrate directly with the Tinker trainer:
+Atropos environments that utilize the following inference pattern are compatible with the Tinker trainer:
 
 ```python
 async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
@@ -45,17 +45,17 @@ async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
     nodes = state["nodes"]
 ```
 
-### How To Implement With An Existing Atropos Environment
+### Implementation Guide for Existing Atropos Environments
 
-1. The `TinkerAtroposConfig` should be loaded in the environment (inside `config.init`), pointing to your desired `config.yaml`, like so:
+1. Load the `TinkerAtroposConfig` within your environment's initialization (inside `config.init`), specifying the path to your desired configuration file:
 
-```
+```python
 config = TinkerAtroposConfig.from_yaml("configs/default.yaml")
 ```
 
-2. The `BaseEnvConfig`, or whatever is overridden for configuration there, should be set up to use these values, like so:
+2. Configure the `BaseEnvConfig` (or your custom configuration class) to utilize the loaded values:
 
-```
+```python
 env_config = BaseEnvConfig(
     tokenizer_name=config.base_model,
     group_size=config.group_size,
@@ -72,7 +72,7 @@ env_config = BaseEnvConfig(
 )
 ```
 
-3. As long as your environment uses the `self.server.managed_server` pattern for inference requests like above, this should *just work*.
+3. Ensure your environment uses the `self.server.managed_server` pattern for inference requests as demonstrated above. No additional modifications are required for Tinker integration.
 
 
 ## Downloading Weights

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ run-api
 
 # Terminal 2: Start training
 export TINKER_API_KEY="<your-key>"
-python launch_training.py --config configs/quick_test.yaml
+python launch_training.py --config configs/default.yaml
 
 # Terminal 3: Start environment
 python tinker_atropos/environments/gsm8k_tinker.py serve

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python launch_training.py --config configs/quick_test.yaml
 python tinker_atropos/environments/gsm8k_tinker.py serve
 ```
 
-This runs a 10-step training example with Llama-3.1-1B on the GSM8k environment.
+This runs a 10-step training example with Llama-3.2-1B on the GSM8k environment. To use a different configuration file for the environment, modify the `CONFIG_PATH` variable at the top of `gsm8k_tinker.py`.
 
 ## Integration with Atropos Environments
 
@@ -95,7 +95,7 @@ Weights will be saved to the specified location.
 
 ## Configuration
 
-The trainer supports YAML configuration files for environment management.
+Both the trainer and environment support YAML configuration files to ensure parameter consistency across your training pipeline. The provided environment file (`gsm8k_tinker.py`) references a configuration path that should match the trainer's configuration. Update the `CONFIG_PATH` variable in the environment file when switching between configurations.
 
 ### Usage
 

--- a/configs/quick_test.yaml
+++ b/configs/quick_test.yaml
@@ -1,17 +1,17 @@
 # Quick test configuration with minimal resources
 # Useful for testing the setup and debugging
 
-base_model: "meta-llama/Llama-3.1-1B"
-lora_rank: 16
-learning_rate: 0.0001
+base_model: "meta-llama/Llama-3.2-1B"
+lora_rank: 32
+learning_rate: 0.00004
 
 num_steps: 10
-batch_size: 32
-group_size: 4
-max_token_env_length: 128
-max_token_trainer_length: 512
-max_num_workers: 16
-max_batches_offpolicy: 2
+batch_size: 128
+group_size: 16
+max_token_env_length: 256
+max_token_trainer_length: 2048
+max_num_workers: 24
+max_batches_offpolicy: 3
 
 use_wandb: false
 wandb_project: "atropos-tinker-test"
@@ -22,7 +22,7 @@ inference_api_url: "http://localhost:8001"
 checkpoint_dir: "./temp/"
 save_checkpoint_interval: 0
 
-steps_per_eval: 10
-num_requests_for_eval: 64
+steps_per_eval: 100
+num_requests_for_eval: 256
 
-ensure_scores_not_the_same: true
+ensure_scores_not_the_same: false

--- a/tinker_atropos/environments/gsm8k_tinker.py
+++ b/tinker_atropos/environments/gsm8k_tinker.py
@@ -16,6 +16,8 @@ from atroposlib.envs.base import (
 from atroposlib.type_definitions import Item
 from tinker_atropos.config import TinkerAtroposConfig
 
+CONFIG_PATH = "configs/quick_test.yaml"
+
 question_suffix = " Provide a numerical answer without units, written inside \\boxed{}."
 
 convo_prefix = [
@@ -59,7 +61,9 @@ class GSM8kEnv(BaseEnv):
 
     @classmethod
     def config_init(cls) -> Tuple[BaseEnvConfig, List[APIServerConfig]]:
-        config = TinkerAtroposConfig()
+        config = (
+            TinkerAtroposConfig.from_yaml(CONFIG_PATH) if CONFIG_PATH else TinkerAtroposConfig()
+        )
 
         env_config = BaseEnvConfig(
             tokenizer_name=config.base_model,
@@ -107,6 +111,24 @@ class GSM8kEnv(BaseEnv):
         await super().wandb_log(wandb_metrics)
 
     async def setup(self):
+        # Ensure tokenizer has a chat template
+        if self.tokenizer.chat_template is None:
+            # Set default Llama-style chat template
+            self.tokenizer.chat_template = (
+                "{% for message in messages %}"
+                "{% if message['role'] == 'system' %}"
+                "{{ '<|start_header_id|>system<|end_header_id|>\n\n' + message['content'] + '<|eot_id|>' }}"
+                "{% elif message['role'] == 'user' %}"
+                "{{ '<|start_header_id|>user<|end_header_id|>\n\n' + message['content'] + '<|eot_id|>' }}"
+                "{% elif message['role'] == 'assistant' %}"
+                "{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' + message['content'] + '<|eot_id|>' }}"
+                "{% endif %}"
+                "{% if loop.last and message['role'] != 'assistant' %}"
+                "{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}"
+                "{% endif %}"
+                "{% endfor %}"
+            )
+
         self.train = load_dataset("gsm8k", "main", split="train").shuffle(seed=42)
         test_data = load_dataset("gsm8k", "main", split="test").shuffle(seed=42)
         self.test = list()

--- a/tinker_atropos/environments/gsm8k_tinker.py
+++ b/tinker_atropos/environments/gsm8k_tinker.py
@@ -16,7 +16,7 @@ from atroposlib.envs.base import (
 from atroposlib.type_definitions import Item
 from tinker_atropos.config import TinkerAtroposConfig
 
-CONFIG_PATH = "configs/quick_test.yaml"
+CONFIG_PATH = "configs/default.yaml"
 
 question_suffix = " Provide a numerical answer without units, written inside \\boxed{}."
 

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -327,6 +327,7 @@ class TinkerAtroposTrainer:
         step_time = time.time() - step_start
         metrics["step_time"] = step_time
         metrics["learning_rate"] = self.learning_rate
+        metrics["loss"] = fwd_bwd_result.metrics["loss:sum"]
 
         if self.group_mean_rewards:
             metrics["reward/mean"] = np.mean(self.group_mean_rewards)


### PR DESCRIPTION
This PR covers a handful of small changes:
1. Cleans up README language
2. Adds Rate Card for Tinker and some further documentation for integration of Atropos environments
3. Edits the `quick_test.yaml` to have more realistic parameters
4. Sets default quickstart run to use the default model for parity with what we've been developing on (Llama-3.1-8B)
5. Adds chat templating and loss outputs to trainer