### PR TITLE
Parity changes for Tinker RL implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export TINKER_API_KEY="<your-key>"
 python launch_training.py --config configs/default.yaml --num-steps 10
 
 # Terminal 3: Start environment
-python tinker_atropos/environments/gsm8k_tinker.py serve
+python tinker_atropos/environments/gsm8k_tinker.py serve --config configs/default.yaml
 ```
 
 This runs a 10-step training example with Llama-3.1-8B-Instruct on the GSM8k environment. To use a different configuration file for the environment, modify the `CONFIG_PATH` variable at the top of `gsm8k_tinker.py`.
@@ -115,14 +115,63 @@ python launch_training.py --config configs/default.yaml --num-steps 100 --no-wan
 - `default.yaml` - Standard configuration for typical training runs
 - `quick_test.yaml` - Minimal configuration for testing and debugging
 
-### Configuration Options
+### Configuration Structure
 
-- **Tinker / Model Parameters**: `base_model`, `lora_rank`, `learning_rate`
-- **Training**: `num_steps`, `batch_size`, `group_size`, `max_token_env_length`, `max_token_trainer_length`
-- **Wandb**: `use_wandb`, `wandb_project`, `wandb_group`, `wandb_run_name`
-- **APIs**: `atropos_api_url`, `inference_api_url`
+Configs follow the Atropos format with a `tinker` section for Tinker-specific settings:
 
-See `configs/` for complete parameter lists.
+```yaml
+env:
+  # Standard Atropos environment config
+  group_size: 16
+  batch_size: 128
+  tokenizer_name: "meta-llama/Llama-3.1-8B-Instruct"
+  # ... more settings
+
+openai:
+  # Standard Atropos server config
+  - model_name: "meta-llama/Llama-3.1-8B-Instruct"
+    base_url: "http://localhost:8001/v1"
+    # ... more settings
+
+tinker:
+  # Tinker-specific training config
+  lora_rank: 32
+  learning_rate: 0.00004
+  # ... more settings
+```
+
+See `configs/default.yaml` for the complete configuration options.
+
+### Adapting Existing Atropos Configs
+
+To use an existing Atropos environment config with Tinker:
+
+1. Add a `tinker` section with training parameters:
+   ```yaml
+   tinker:
+     lora_rank: 32
+     learning_rate: 0.00004
+     max_token_trainer_length: 2048
+     checkpoint_dir: "./checkpoints/"
+     save_checkpoint_interval: 0
+     wandb_project: "my-project"
+     wandb_group: null
+     wandb_run_name: "my-run"
+   ```
+
+2. Ensure your environment uses `managed_server` with stop sequences:
+   ```python
+   async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
+       chat_completion = await managed.chat_completion(
+           messages=messages,
+           n=self.config.group_size,
+           max_tokens=self.config.max_token_length,
+           temperature=1.0,
+           stop=[self.tokenizer.eos_token_id],  # Add stop sequences
+       )
+   ```
+
+3. That's it! The config is ready to use with both Atropos and Tinker.
 
 ### Programmatic Usage
 
@@ -133,11 +182,22 @@ from tinker_atropos.trainer import TinkerAtroposTrainer
 # Load from YAML
 config = TinkerAtroposConfig.from_yaml("configs/default.yaml")
 
-# Or use defaults
+# Access nested config values
+print(f"Model: {config.env.tokenizer_name}")
+print(f"LoRA rank: {config.tinker.lora_rank}")
+print(f"Group size: {config.env.group_size}")
+
+# Or use convenience properties
+print(f"Model: {config.base_model}")  # -> config.env.tokenizer_name
+print(f"LoRA rank: {config.lora_rank}")  # -> config.tinker.lora_rank
+print(f"Learning rate: {config.learning_rate}")  # -> config.tinker.learning_rate
+
+# Use defaults (creates default config)
 config = TinkerAtroposConfig()
 
-# Initialize trainer
+# Initialize and run trainer
 trainer = TinkerAtroposTrainer(config=config)
+await trainer.run()
 ```
 
 ## Testing

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,37 +1,41 @@
-# Default configuration for Tinker-Atropos training
-# This file demonstrates all available configuration options
+# Tinker-Atropos Configuration
 
-# Model configuration
-base_model: "meta-llama/Llama-3.1-8B-Instruct"
-lora_rank: 32
-learning_rate: 0.00004
+# Environment configuration
+env:
+  group_size: 16
+  batch_size: 128
+  max_batches_offpolicy: 3
+  tokenizer_name: "meta-llama/Llama-3.1-8B-Instruct"
+  use_wandb: true
+  rollout_server_url: "http://localhost:8000"
+  wandb_name: "atropos-tinker-env"
+  ensure_scores_not_the_same: false
+  max_token_length: 256
+  max_num_workers: 24
+  total_steps: 50
+  steps_per_eval: 100
 
-# Training configuration
-num_steps: 50
-batch_size: 128
-group_size: 16
-max_token_env_length: 256
-max_token_trainer_length: 2048
-max_num_workers: 24
-max_batches_offpolicy: 3
+# OpenAI-compatible server configuration
+openai:
+  - model_name: "meta-llama/Llama-3.1-8B-Instruct"
+    base_url: "http://localhost:8001/v1"
+    api_key: "x"
+    weight: 1.0
+    num_requests_for_eval: 256
 
-# Weights & Biases configuration
-use_wandb: true
-wandb_project: "atropos-tinker"
-wandb_group: null  # Will be auto-generated if not specified
-wandb_run_name: "atropos-tinker-run"
+# Tinker-specific configuration
+tinker:
+  lora_rank: 32
+  learning_rate: 0.00004
+  max_token_trainer_length: 2048
+  checkpoint_dir: "./temp/"
+  save_checkpoint_interval: 0
 
-# API endpoints
-atropos_api_url: "http://localhost:8000"
-inference_api_url: "http://localhost:8001"
+  # Wandb configuration for trainer
+  wandb_project: "atropos-tinker"
+  wandb_group: null  # Will be auto-generated if not specified
+  wandb_run_name: "atropos-tinker-run"
 
-# Checkpoint configuration (needed for Atropos BaseEnvConfig - not used)
-checkpoint_dir: "./temp/"
-save_checkpoint_interval: 0
-
-# Evaluation configuration
-steps_per_eval: 100
-num_requests_for_eval: 256
-
-# Training options
-ensure_scores_not_the_same: false
+# Standard Atropos flags
+slurm: false
+testing: false

--- a/configs/quick_test.yaml
+++ b/configs/quick_test.yaml
@@ -1,28 +1,39 @@
 # Quick test configuration with minimal resources
 # Useful for testing the setup and debugging
 
-base_model: "meta-llama/Llama-3.2-1B"
-lora_rank: 32
-learning_rate: 0.00004
+# Environment configuration
+env:
+  group_size: 16
+  batch_size: 128
+  max_batches_offpolicy: 3
+  tokenizer_name: "meta-llama/Llama-3.2-1B"
+  use_wandb: false
+  rollout_server_url: "http://localhost:8000"
+  wandb_name: "atropos-tinker-test-env"
+  ensure_scores_not_the_same: false
+  max_token_length: 256
+  max_num_workers: 24
+  total_steps: 10
+  steps_per_eval: 100
 
-num_steps: 10
-batch_size: 128
-group_size: 16
-max_token_env_length: 256
-max_token_trainer_length: 2048
-max_num_workers: 24
-max_batches_offpolicy: 3
+# OpenAI-compatible server configuration
+openai:
+  - model_name: "meta-llama/Llama-3.2-1B"
+    base_url: "http://localhost:8001/v1"
+    api_key: "x"
+    weight: 1.0
+    num_requests_for_eval: 256
 
-use_wandb: false
-wandb_project: "atropos-tinker-test"
+# Tinker-specific configuration
+tinker:
+  lora_rank: 32
+  learning_rate: 0.00004
+  max_token_trainer_length: 2048
+  checkpoint_dir: "./temp/"
+  save_checkpoint_interval: 0
+  wandb_project: "atropos-tinker-test"
+  wandb_group: null
+  wandb_run_name: "atropos-tinker-test-run"
 
-atropos_api_url: "http://localhost:8000"
-inference_api_url: "http://localhost:8001"
-
-checkpoint_dir: "./temp/"
-save_checkpoint_interval: 0
-
-steps_per_eval: 100
-num_requests_for_eval: 256
-
-ensure_scores_not_the_same: false
+slurm: false
+testing: false

--- a/tinker_atropos/config.py
+++ b/tinker_atropos/config.py
@@ -1,11 +1,10 @@
 import random
 import string
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Dict, Any
 
 import yaml
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, Field
 
 
 def generate_run_suffix() -> str:
@@ -13,52 +12,164 @@ def generate_run_suffix() -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
 
 
-# Values here are set as the default values when not using a config YAML
-class TinkerAtroposConfig(BaseSettings):
-    model_config = SettingsConfigDict(
-        env_prefix="TINKER_ATROPOS_",
-        env_file=".env",
-        env_file_encoding="utf-8",
-        case_sensitive=False,
-        extra="ignore",
-    )
+class EnvConfig(BaseModel):
+    """Environment configuration - matches Atropos BaseEnvConfig"""
 
-    base_model: str = "meta-llama/Llama-3.1-8B-Instruct"
+    group_size: int = 16
+    batch_size: int = 128
+    max_batches_offpolicy: int = 3
+    tokenizer_name: str = "meta-llama/Llama-3.1-8B-Instruct"
+    use_wandb: bool = True
+    rollout_server_url: str = "http://localhost:8000"
+    wandb_name: str = "atropos-tinker-env"
+    ensure_scores_not_the_same: bool = False
+    max_token_length: int = 256
+    max_num_workers: int = 24
+    total_steps: int = 50
+    steps_per_eval: int = 100
+
+
+class OpenAIServerConfig(BaseModel):
+    """OpenAI-compatible server configuration"""
+
+    model_name: str
+    base_url: str
+    api_key: str = "x"
+    weight: float = 1.0
+    num_requests_for_eval: int = 256
+
+
+class TinkerConfig(BaseModel):
+    """Tinker-specific configuration for LoRA training"""
+
     lora_rank: int = 32
     learning_rate: float = 4e-5
+    max_token_trainer_length: int = 2048
+    checkpoint_dir: str = "./temp/"
+    save_checkpoint_interval: int = 0
 
-    # Training hyperparameters
-    num_steps: int = 100
-    batch_size: int = 128  # Number of datums per training batch
-    group_size: int = 16  # Number of rollouts per question
-    max_token_env_length: int = 256  # Max tokens for environment rollouts
-    max_token_trainer_length: int = 2048  # Max tokens for trainer processing
-    max_num_workers: int = 24  # Max parallel workers for rollout generation
-    max_batches_offpolicy: int = 3  # Max batches before data is considered too stale
-
-    # Wandb configuration
-    use_wandb: bool = True
+    # Wandb configuration for trainer
     wandb_project: str = "atropos-tinker"
     wandb_group: Optional[str] = None
     wandb_run_name: str = "atropos-tinker-run"
     wandb_run_suffix: str = Field(default_factory=generate_run_suffix)
 
-    # API endpoints
-    atropos_api_url: str = "http://localhost:8000"  # Atropos rollout server
-    inference_api_url: str = "http://localhost:8001"  # Unified trainer inference endpoint
 
-    # Checkpointing
-    checkpoint_dir: str = "./temp/"
-    save_checkpoint_interval: int = 0
+class TinkerAtroposConfig(BaseModel):
+    """Complete Tinker-Atropos configuration"""
 
-    # Evaluation
-    steps_per_eval: int = 100
-    num_requests_for_eval: int = 256
+    env: EnvConfig = Field(default_factory=EnvConfig)
+    openai: List[OpenAIServerConfig] = Field(
+        default_factory=lambda: [
+            OpenAIServerConfig(
+                model_name="meta-llama/Llama-3.1-8B-Instruct",
+                base_url="http://localhost:8001/v1",
+            )
+        ]
+    )
+    tinker: TinkerConfig = Field(default_factory=TinkerConfig)
+    slurm: bool = False
+    testing: bool = False
 
-    # Debug options
-    ensure_scores_not_the_same: bool = False
+    # Convenience properties
+    @property
+    def base_model(self) -> str:
+        """Convenience accessor for model name"""
+        return self.env.tokenizer_name
 
-    def to_dict(self):
+    @property
+    def atropos_api_url(self) -> str:
+        """Convenience accessor for Atropos API URL"""
+        return self.env.rollout_server_url
+
+    @property
+    def inference_api_url(self) -> str:
+        """Convenience accessor for inference server URL (first OpenAI server)"""
+        if self.openai:
+            # Remove /v1 suffix if present
+            url = self.openai[0].base_url
+            return url.rstrip("/v1").rstrip("/")
+        return "http://localhost:8001"
+
+    @property
+    def group_size(self) -> int:
+        return self.env.group_size
+
+    @property
+    def batch_size(self) -> int:
+        return self.env.batch_size
+
+    @property
+    def max_batches_offpolicy(self) -> int:
+        return self.env.max_batches_offpolicy
+
+    @property
+    def use_wandb(self) -> bool:
+        return self.env.use_wandb
+
+    @property
+    def num_steps(self) -> int:
+        return self.env.total_steps
+
+    @property
+    def steps_per_eval(self) -> int:
+        return self.env.steps_per_eval
+
+    @property
+    def max_token_env_length(self) -> int:
+        return self.env.max_token_length
+
+    @property
+    def max_num_workers(self) -> int:
+        return self.env.max_num_workers
+
+    @property
+    def ensure_scores_not_the_same(self) -> bool:
+        return self.env.ensure_scores_not_the_same
+
+    @property
+    def wandb_run_name(self) -> str:
+        return self.tinker.wandb_run_name
+
+    @property
+    def wandb_project(self) -> str:
+        return self.tinker.wandb_project
+
+    @property
+    def wandb_group(self) -> Optional[str]:
+        return self.tinker.wandb_group
+
+    @property
+    def wandb_run_suffix(self) -> str:
+        return self.tinker.wandb_run_suffix
+
+    @property
+    def lora_rank(self) -> int:
+        return self.tinker.lora_rank
+
+    @property
+    def learning_rate(self) -> float:
+        return self.tinker.learning_rate
+
+    @property
+    def max_token_trainer_length(self) -> int:
+        return self.tinker.max_token_trainer_length
+
+    @property
+    def checkpoint_dir(self) -> str:
+        return self.tinker.checkpoint_dir
+
+    @property
+    def save_checkpoint_interval(self) -> int:
+        return self.tinker.save_checkpoint_interval
+
+    @property
+    def num_requests_for_eval(self) -> int:
+        if self.openai:
+            return self.openai[0].num_requests_for_eval
+        return 256
+
+    def to_dict(self) -> Dict[str, Any]:
         return self.model_dump()
 
     @classmethod

--- a/tinker_atropos/environments/gsm8k_tinker.py
+++ b/tinker_atropos/environments/gsm8k_tinker.py
@@ -270,6 +270,7 @@ class GSM8kEnv(BaseEnv):
                 n=self.config.group_size,
                 max_tokens=self.config.max_token_length,
                 temperature=1.0,
+                stop=[self.tokenizer.eos_token_id],
             )
 
             state = managed.get_state()

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -149,12 +149,12 @@ class TinkerAtroposTrainer:
             original_mean = np.mean(scores)
             advantages = scores - original_mean
 
+            group_mean_rewards.append(original_mean)
+
             # Skip groups where all advantages are zero
             if len(scores) > 1 and np.all(advantages == 0.0):
                 skipped_count += 1
                 continue
-
-            group_mean_rewards.append(original_mean)
 
             # Apply advantage overrides
             if item.get("overrides") is not None:
@@ -286,7 +286,11 @@ class TinkerAtroposTrainer:
         fwd_bwd_result = await fwd_bwd_result.result_async()
         optim_result = await optim_result.result_async()
 
-        print(f"Loss: {fwd_bwd_result.metrics['loss:sum']}")
+        loss_val = (
+            fwd_bwd_result.metrics["loss:sum"] if "loss:sum" in fwd_bwd_result.metrics else 0.0
+        )
+
+        print(f"Loss: {loss_val}")
 
         # Calculate training logprob stats
         training_logprobs_all = []
@@ -327,7 +331,7 @@ class TinkerAtroposTrainer:
         step_time = time.time() - step_start
         metrics["step_time"] = step_time
         metrics["learning_rate"] = self.learning_rate
-        metrics["loss"] = fwd_bwd_result.metrics["loss:sum"]
+        metrics["loss"] = loss_val
 
         if self.group_mean_rewards:
             metrics["reward/mean"] = np.mean(self.group_mean_rewards)
@@ -335,7 +339,7 @@ class TinkerAtroposTrainer:
 
         if self.config.use_wandb:
             wandb_metrics = {
-                "train/loss": fwd_bwd_result.metrics["loss:sum"],
+                "train/loss": loss_val,
                 "train/learning_rate": self.learning_rate,
                 "reward/mean": metrics["reward/mean"],
             }


### PR DESCRIPTION
This PR does the following 3 things:
- Adds stop tokens to managed server inference request
- Moves reward calculation to happen before advantage skipping in the group
- Sets the loss values to default to 0.0 if no value is set

All 3 of these were done to match the Tinker implementation in `rl_loop.py`.