### PR TITLE
Debug Flag in Config and Timing API Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ python launch_training.py --config configs/math_config.yaml
 python ~/atropos/environments/math_server.py serve --config configs/math_config.yaml
 ```
 
+**NOTE:** The `server_type` field in your environment config must be set to "sglang" for this to work properly. We are in the process of updating this upstream to be agnostic to any `server_type`, but for now "sglang" is the functionally correct way to implement a new environment.
+
 ### How It Works
 
 Atropos environments support a `--config` flag that loads your Tinker config (which follows the standard Atropos format with a `tinker` section). The environment uses:

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -31,6 +31,9 @@ tinker:
   checkpoint_dir: "./temp/"
   save_checkpoint_interval: 0
 
+  # Debug configuration
+  debug: false  # Enable to log timing for training and inference API calls
+
   # Wandb configuration for trainer
   wandb_project: "atropos-tinker"
   wandb_group: null  # Will be auto-generated if not specified

--- a/tinker_atropos/config.py
+++ b/tinker_atropos/config.py
@@ -48,6 +48,9 @@ class TinkerConfig(BaseModel):
     checkpoint_dir: str = "./temp/"
     save_checkpoint_interval: int = 0
 
+    # Debug configuration
+    debug: bool = False
+
     # Wandb configuration for trainer
     wandb_project: str = "atropos-tinker"
     wandb_group: Optional[str] = None
@@ -168,6 +171,10 @@ class TinkerAtroposConfig(BaseModel):
         if self.openai:
             return self.openai[0].num_requests_for_eval
         return 256
+
+    @property
+    def debug(self) -> bool:
+        return self.tinker.debug
 
     def to_dict(self) -> Dict[str, Any]:
         return self.model_dump()

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -274,6 +274,8 @@ class TinkerAtroposTrainer:
 
         # Forward-backward pass with importance sampling loss
         print("Running forward-backward pass...")
+        if self.config.debug:
+            fwd_bwd_start = time.time()
         fwd_bwd_result = await self.training_client.forward_backward_async(
             data, loss_fn="importance_sampling"
         )
@@ -281,10 +283,21 @@ class TinkerAtroposTrainer:
         # Optimizer step
         print("Running optimizer step...")
         adam_params = AdamParams(learning_rate=self.learning_rate, beta1=0.9, beta2=0.95, eps=1e-8)
+        if self.config.debug:
+            optim_start = time.time()
         optim_result = await self.training_client.optim_step_async(adam_params)
 
         fwd_bwd_result = await fwd_bwd_result.result_async()
+        if self.config.debug:
+            fwd_bwd_time = time.time() - fwd_bwd_start
+            print(f"[DEBUG] Forward-backward pass took: {fwd_bwd_time:.3f}s")
+            metrics["time/fwd_bwd"] = fwd_bwd_time
+
         optim_result = await optim_result.result_async()
+        if self.config.debug:
+            optim_time = time.time() - optim_start
+            print(f"[DEBUG] Optimizer step took: {optim_time:.3f}s")
+            metrics["time/optim"] = optim_time
 
         loss_val = (
             fwd_bwd_result.metrics["loss:sum"] if "loss:sum" in fwd_bwd_result.metrics else 0.0
@@ -320,9 +333,15 @@ class TinkerAtroposTrainer:
 
         # Update sampling client with new weights
         print("Saving checkpoint and updating sampling client...")
+        if self.config.debug:
+            save_weights_start = time.time()
         new_path = (
             self.training_client.save_weights_for_sampler(name=f"step_{step+1}").result().path
         )
+        if self.config.debug:
+            save_weights_time = time.time() - save_weights_start
+            print(f"[DEBUG] Save weights took: {save_weights_time:.3f}s")
+            metrics["time/save_weights"] = save_weights_time
         self.current_sampling_client = self.service_client.create_sampling_client(
             model_path=new_path
         )
@@ -350,6 +369,12 @@ class TinkerAtroposTrainer:
                 wandb_metrics.update(self.training_logprob_stats)
             if hasattr(self, "advantage_stats"):
                 wandb_metrics.update(self.advantage_stats)
+
+            # Add timing metrics if debug mode is enabled
+            if self.config.debug:
+                for key in ["time/fwd_bwd", "time/optim", "time/save_weights"]:
+                    if key in metrics:
+                        wandb_metrics[key] = metrics[key]
 
             wandb.log(wandb_metrics, step=step + 1)
 
@@ -429,11 +454,16 @@ async def completions(request: CompletionRequest):
                 stop=request.stop if request.stop else [],
             )
 
+            if trainer.config.debug:
+                inference_start = time.time()
             result = await trainer.current_sampling_client.sample_async(
                 prompt=model_input,
                 sampling_params=sampling_params,
                 num_samples=request.n,
             )
+            if trainer.config.debug:
+                inference_time = time.time() - inference_start
+                print(f"[DEBUG] Inference took: {inference_time:.3f}s")
 
             # Format choices
             for sequence in result.sequences:
@@ -495,11 +525,16 @@ async def chat_completions(request: ChatCompletionRequest):
             stop=request.stop if request.stop else [],
         )
 
+        if trainer.config.debug:
+            inference_start = time.time()
         result = await trainer.current_sampling_client.sample_async(
             prompt=model_input,
             sampling_params=sampling_params,
             num_samples=request.n,
         )
+        if trainer.config.debug:
+            inference_time = time.time() - inference_start
+            print(f"[DEBUG] Inference took: {inference_time:.3f}s")
 
         # Format as OpenAI response
         choices = []
@@ -559,11 +594,16 @@ async def generate(request: GenerateRequest):
             stop=stop if isinstance(stop, list) else [stop],
         )
 
+        if trainer.config.debug:
+            inference_start = time.time()
         result = await trainer.current_sampling_client.sample_async(
             prompt=model_input,
             sampling_params=tinker_sampling_params,
             num_samples=n,
         )
+        if trainer.config.debug:
+            inference_time = time.time() - inference_start
+            print(f"[DEBUG] Inference took: {inference_time:.3f}s")
 
         if n == 1:
             sequence = result.sequences[0]


### PR DESCRIPTION
This PR is a simple, small one, that does two things:

1. Updates `README.md` to include a note specifying the `server_type` field in environment configurations needs to be "sglang".

2. Adds a `debug` flag to `config.py` and the default YAML config to allow for debug mode, which, in this initial case, outputs the timing of all API calls to Tinker and logs them to wandb.

## Testing

N/A