### PR TITLE
fix: apply CLI and env-var config overrides instead of silently dropping them

### DIFF
--- a/launch_training.py
+++ b/launch_training.py
@@ -51,33 +51,45 @@ def load_config(args) -> TinkerAtroposConfig:
         print("Using default configuration")
         config = TinkerAtroposConfig()
 
-    # Apply CLI overrides
+    # Apply CLI overrides directly onto the nested config fields.
+    #
+    # The flat names below (base_model, lora_rank, num_steps, ...) are
+    # read-only convenience @property accessors on TinkerAtroposConfig, not
+    # model fields. Feeding them back as top-level kwargs via
+    # `TinkerAtroposConfig(**config_dict)` silently dropped every override,
+    # because pydantic v2 defaults to extra="ignore". Assign the underlying
+    # env/tinker fields instead so the overrides actually take effect.
     overrides = {}
     if args.base_model:
+        config.env.tokenizer_name = args.base_model
         overrides["base_model"] = args.base_model
     if args.lora_rank is not None:
+        config.tinker.lora_rank = args.lora_rank
         overrides["lora_rank"] = args.lora_rank
     if args.learning_rate is not None:
+        config.tinker.learning_rate = args.learning_rate
         overrides["learning_rate"] = args.learning_rate
     if args.num_steps is not None:
+        config.env.total_steps = args.num_steps
         overrides["num_steps"] = args.num_steps
     if args.batch_size is not None:
+        config.env.batch_size = args.batch_size
         overrides["batch_size"] = args.batch_size
     if args.group_size is not None:
+        config.env.group_size = args.group_size
         overrides["group_size"] = args.group_size
     if args.wandb_project:
+        config.tinker.wandb_project = args.wandb_project
         overrides["wandb_project"] = args.wandb_project
     if args.wandb_group:
+        config.tinker.wandb_group = args.wandb_group
         overrides["wandb_group"] = args.wandb_group
     if args.no_wandb:
+        config.env.use_wandb = False
         overrides["use_wandb"] = False
 
-    # Create new config with overrides if any were provided
     if overrides:
         print(f"Applying CLI overrides: {overrides}")
-        config_dict = config.to_dict()
-        config_dict.update(overrides)
-        config = TinkerAtroposConfig(**config_dict)
 
     return config
 

--- a/tinker_atropos/tests/test_config_overrides.py
+++ b/tinker_atropos/tests/test_config_overrides.py
@@ -1,0 +1,90 @@
+"""Regression tests for CLI / env-var config overrides.
+
+The flat accessors on ``TinkerAtroposConfig`` (``lora_rank``, ``num_steps``,
+``base_model`` ...) are read-only ``@property`` wrappers around the nested
+``env`` / ``tinker`` fields, not model fields themselves. Passing them as
+top-level kwargs let pydantic's default ``extra="ignore"`` silently drop them,
+so both the ``--lora-rank`` style CLI flags and the ``LORA_RANK`` /
+``LEARNING_RATE`` env vars had no effect. These tests pin the fix.
+"""
+
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+# launch_training.py lives at the repo root, next to the package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from launch_training import load_config  # noqa: E402
+from tinker_atropos.trainer import build_config_from_env  # noqa: E402
+
+
+def _args(**overrides) -> Namespace:
+    defaults = dict(
+        config=None,
+        base_model=None,
+        lora_rank=None,
+        learning_rate=None,
+        num_steps=None,
+        batch_size=None,
+        group_size=None,
+        wandb_project=None,
+        wandb_group=None,
+        no_wandb=False,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+class TestCLIOverrides:
+    def test_overrides_reach_nested_fields(self):
+        config = load_config(
+            _args(
+                base_model="OVERRIDDEN",
+                lora_rank=64,
+                learning_rate=1e-3,
+                num_steps=7,
+                batch_size=4,
+                group_size=2,
+                wandb_project="proj",
+                wandb_group="grp",
+                no_wandb=True,
+            )
+        )
+        # Values must land on the real nested fields (and be visible via the
+        # convenience properties), not be silently discarded.
+        assert config.base_model == "OVERRIDDEN"
+        assert config.env.tokenizer_name == "OVERRIDDEN"
+        assert config.lora_rank == 64
+        assert config.tinker.lora_rank == 64
+        assert config.learning_rate == 1e-3
+        assert config.num_steps == 7
+        assert config.env.total_steps == 7
+        assert config.batch_size == 4
+        assert config.group_size == 2
+        assert config.wandb_project == "proj"
+        assert config.wandb_group == "grp"
+        assert config.use_wandb is False
+
+    def test_no_overrides_keeps_defaults(self):
+        config = load_config(_args())
+        assert config.lora_rank == 32
+        assert config.num_steps == 50
+        assert config.use_wandb is True
+
+
+class TestEnvOverrides:
+    def test_env_vars_reach_nested_fields(self, monkeypatch):
+        monkeypatch.setenv("LORA_RANK", "128")
+        monkeypatch.setenv("LEARNING_RATE", "2e-4")
+        config = build_config_from_env()
+        assert config.lora_rank == 128
+        assert config.learning_rate == 2e-4
+        assert config.num_steps == 50
+
+    def test_env_defaults_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LORA_RANK", raising=False)
+        monkeypatch.delenv("LEARNING_RATE", raising=False)
+        config = build_config_from_env()
+        assert config.lora_rank == 32
+        assert config.learning_rate == 4e-5

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -25,7 +25,7 @@ from tinker_atropos.types import (
     LogprobsResponse,
     TokenLogprob,
 )
-from tinker_atropos.config import TinkerAtroposConfig
+from tinker_atropos.config import TinkerAtroposConfig, EnvConfig, TinkerConfig
 
 
 class TinkerAtroposTrainer:
@@ -837,14 +837,27 @@ def run_fastapi_server():
     uvicorn.run(app, host="0.0.0.0", port=8001, log_level="info")
 
 
+def build_config_from_env() -> TinkerAtroposConfig:
+    """Build the training config, honoring LORA_RANK / LEARNING_RATE env vars.
+
+    lora_rank / learning_rate / num_steps are read-only convenience properties
+    on TinkerAtroposConfig, so passing them as top-level kwargs let pydantic's
+    default extra="ignore" drop them and the env vars never applied. Set the
+    real nested EnvConfig / TinkerConfig fields instead.
+    """
+    return TinkerAtroposConfig(
+        env=EnvConfig(total_steps=50),
+        tinker=TinkerConfig(
+            lora_rank=int(os.getenv("LORA_RANK", "32")),
+            learning_rate=float(os.getenv("LEARNING_RATE", "4e-5")),
+        ),
+    )
+
+
 async def main():
     global trainer
 
-    config = TinkerAtroposConfig(
-        lora_rank=int(os.getenv("LORA_RANK", "32")),
-        learning_rate=float(os.getenv("LEARNING_RATE", "4e-5")),
-        num_steps=50,
-    )
+    config = build_config_from_env()
 
     print(f"Using wandb run: {config.wandb_run_name}")
 


### PR DESCRIPTION
The flat accessors on `TinkerAtroposConfig` (`lora_rank`, `learning_rate`, `num_steps`, `base_model`, `batch_size`, `group_size`, `use_wandb`, `wandb_project`, `wandb_group`) are read-only `@property` wrappers around the nested `env` / `tinker` fields. They aren't model fields. Passing them back as top-level kwargs made pydantic v2 drop them under its default `extra="ignore"`, so config overrides did nothing.

### Two affected entry points

**`launch_training.py`** (CLI flags `--lora-rank`, `--num-steps`, …)

`load_config()` did:

```python
config_dict = config.to_dict()          # nested: {"env": {...}, "tinker": {...}}
config_dict.update(overrides)           # flat:   {"lora_rank": 64, ...}
config = TinkerAtroposConfig(**config_dict)   # flat keys ignored -> dropped
```

The program still prints `Applying CLI overrides: {...}`, so the user believes the flags took effect while training runs on the YAML/default values.

**`trainer.py` `main()`** (`LORA_RANK` / `LEARNING_RATE` env vars)

```python
config = TinkerAtroposConfig(
    lora_rank=int(os.getenv("LORA_RANK", "32")),      # ignored
    learning_rate=float(os.getenv("LEARNING_RATE", "4e-5")),  # ignored
    num_steps=50,                                     # ignored
)
```

These get dropped too. It only appears to work because the hardcoded defaults happen to equal the env-var defaults, so `LORA_RANK=64` still trains rank 32.

### Repro (before)

```python
c = TinkerAtroposConfig()
d = c.to_dict(); d.update({"lora_rank": 64, "num_steps": 7})
TinkerAtroposConfig(**d).lora_rank   # -> 32  (override lost)
TinkerAtroposConfig(lora_rank=64).lora_rank   # -> 32  (env-var path)
```

### Fix

- `load_config()` assigns the underlying nested `env` / `tinker` fields directly (and keeps the `Applying CLI overrides` log).
- `main()` builds the config from a new `build_config_from_env()` helper that sets the nested fields, making the env-var path unit-testable.

### Tests

Adds `tinker_atropos/tests/test_config_overrides.py` covering both entry points. It checks that CLI overrides reach the nested fields, env vars are honored, and defaults are preserved when nothing is overridden. All assertions fail on `main` and pass with this change.

### Type of change

Bug fix (non-breaking).