### PR TITLE
fix: don't drop on-policy-distillation groups via zero-advantage skip

### DIFF
--- a/tinker_atropos/tests/test_distillation.py
+++ b/tinker_atropos/tests/test_distillation.py
@@ -252,6 +252,99 @@ class TestDistillValidation:
         assert result is None
 
 
+class TestZeroAdvantageSkip:
+    """The zero-advantage skip must not drop distillation groups.
+
+    For an on-policy-distillation group the per-token signal is
+    (logp_teacher - logp_student), which is independent of the RL scores. A
+    distillation group whose trajectories all have equal scores has all-zero
+    RL advantages, but its teacher signal is still valid and must be kept.
+    """
+
+    def test_distill_group_with_equal_scores_not_skipped(self, trainer):
+        """Equal scores -> zero RL advantages, but distill group is kept."""
+        group_size = 2
+        batch = make_batch(
+            tokens_list=[
+                [1, 2, 3, 4, 5],
+                [1, 2, 3, 4, 6],
+            ],
+            # Prompt sentinel (1.0) for first two positions, then student logprobs.
+            logprobs_list=[
+                [1.0, 1.0, -0.5, -0.3, -0.2],
+                [1.0, 1.0, -0.4, -0.35, -0.25],
+            ],
+            # Equal scores => RL advantages all 0.0 => would be skipped if not distil.
+            scores=[1.0, 1.0],
+            distill_token_ids=[
+                [[1], [2], [3], [4], [5]],
+                [[1], [2], [3], [4], [6]],
+            ],
+            distill_logprobs=[
+                [[-0.1], [-0.1], [-0.8], [-0.6], [-0.4]],
+                [[-0.1], [-0.1], [-0.7], [-0.65], [-0.45]],
+            ],
+        )
+
+        datums, _, has_distil = trainer.pad_data_to_good_offset(batch)
+
+        # Group must NOT be dropped.
+        assert has_distil is True
+        assert len(datums) == group_size
+
+        # Per-token advantages must equal logp_teacher - logp_student, not 0.0.
+        advantages_0 = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+        # After the [1:] shift: positions align with logprobs [1.0, -0.5, -0.3, -0.2]
+        # and teacher logprobs [-0.1, -0.8, -0.6, -0.4].
+        # Position 0: student logprob 1.0 (prompt sentinel) -> advantage 0.0.
+        assert advantages_0[0] == 0.0
+        # Generated positions: teacher - student.
+        assert advantages_0[1] == pytest.approx(-0.8 - (-0.5))
+        assert advantages_0[2] == pytest.approx(-0.6 - (-0.3))
+        assert advantages_0[3] == pytest.approx(-0.4 - (-0.2))
+        # None of the generated-token advantages should be zero here.
+        assert all(a != 0.0 for a in advantages_0[1:])
+
+    def test_non_distill_group_with_equal_scores_still_skipped(self, trainer):
+        """Preserve existing behavior: RL-only group with equal scores is dropped."""
+        batch = make_batch(
+            tokens_list=[
+                [1, 2, 3, 4],
+                [1, 2, 3, 5],
+            ],
+            logprobs_list=[
+                [1.0, 1.0, -0.5, -0.3],
+                [1.0, 1.0, -0.4, -0.2],
+            ],
+            # Equal scores => all-zero RL advantages, no distill => skipped.
+            scores=[1.0, 1.0],
+        )
+
+        datums, _, has_distil = trainer.pad_data_to_good_offset(batch)
+
+        assert has_distil is False
+        assert len(datums) == 0
+
+    def test_rl_group_with_varying_scores_kept(self, trainer):
+        """Sanity: an RL group with non-equal scores is still kept."""
+        batch = make_batch(
+            tokens_list=[
+                [1, 2, 3, 4],
+                [1, 2, 3, 5],
+            ],
+            logprobs_list=[
+                [1.0, 1.0, -0.5, -0.3],
+                [1.0, 1.0, -0.4, -0.2],
+            ],
+            scores=[2.0, 1.0],
+        )
+
+        datums, _, has_distil = trainer.pad_data_to_good_offset(batch)
+
+        assert has_distil is False
+        assert len(datums) == 2
+
+
 class TestConfigInferenceUrl:
     """Test the inference_api_url property fix."""
 

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -217,8 +217,24 @@ class TinkerAtroposTrainer:
 
             group_mean_rewards.append(original_mean)
 
-            # Skip groups where all advantages are zero
-            if len(scores) > 1 and np.all(advantages == 0.0):
+            # Check for distillation data at the group level
+            # Atropos uses "distill_" (double L) field names
+            # This must be determined BEFORE the zero-advantage skip below: for
+            # on-policy-distillation groups the per-token training signal is
+            # (logp_teacher - logp_student), which is independent of the RL
+            # scores. A distillation group with equal scores (e.g. a discrete-
+            # reward distillation env) has all-zero RL advantages but still
+            # carries a valid teacher signal, so it must not be dropped.
+            item_has_distil = (
+                item.get("distill_token_ids") is not None
+                and item.get("distill_logprobs") is not None
+            )
+            if item_has_distil:
+                has_distil_data = True
+
+            # Skip groups where all RL advantages are zero, but never skip
+            # distillation groups (their signal does not come from advantages).
+            if not item_has_distil and len(scores) > 1 and np.all(advantages == 0.0):
                 skipped_count += 1
                 continue
 
@@ -227,15 +243,6 @@ class TinkerAtroposTrainer:
                 for i in range(len(item["overrides"])):
                     if item["overrides"][i].get("set_advantage_to_zero", False):
                         advantages[i] = 0.0
-
-            # Check for distillation data at the group level
-            # Atropos uses "distill_" (double L) field names
-            item_has_distil = (
-                item.get("distill_token_ids") is not None
-                and item.get("distill_logprobs") is not None
-            )
-            if item_has_distil:
-                has_distil_data = True
 
             for i in range(len(item["tokens"])):
                 tokens = item["tokens"][i]


### PR DESCRIPTION
## What
`pad_data_to_good_offset` in `tinker_atropos/trainer.py` drops on-policy-distillation groups when every trajectory in the group has the same score.

## Cause
The function skips groups where all RL advantages are zero:

```python
if len(scores) > 1 and np.all(advantages == 0.0):
    skipped_count += 1
    continue
```

This guard runs before `item_has_distil` is computed. For an on-policy-distillation group the per-token training signal is `advantage = logp_teacher - logp_student`, which gets overwritten later in the same function and is independent of the RL scores. If a distillation group's trajectories all share the same `score`, which is common for a discrete or equal-reward distillation env, its RL advantages are all zero. The guard then threw away a valid teacher-distillation signal.

## Fix
Compute `item_has_distil` before the skip and exclude distillation groups from the zero-advantage guard:

```python
if not item_has_distil and len(scores) > 1 and np.all(advantages == 0.0):
    skipped_count += 1
    continue
```

RL-only behavior is unchanged. A non-distillation group with all-equal scores is still skipped. A now-kept distillation group flows into the existing distillation path, which overwrites `advantages` with `logp_teacher - logp_student`.

## Test
Added tests in `tinker_atropos/tests/test_distillation.py` (`TestZeroAdvantageSkip`):
- A distillation group with equal scores (all-zero RL advantages) plus valid `distill_token_ids`/`distill_logprobs` is not dropped (`len(datums) == group_size`), and its per-token advantages equal `logp_teacher - logp_student`.
- A non-distillation group with equal scores is still skipped (`len(datums) == 0`), preserving existing behavior.
- An RL group with varying scores is still kept.

Verified the new test fails on the pre-fix code (group dropped, "Skipped 1 groups with zero advantages") and passes after the fix. The full `test_distillation.py` suite (21 tests) passes.

This mainly protects distillation envs with discrete or equal rewards, whose valid teacher signal was previously discarded.