### PR TITLE
fix: honor set_advantage_to_zero override under distillation

### DIFF
--- a/tinker_atropos/tests/test_distillation.py
+++ b/tinker_atropos/tests/test_distillation.py
@@ -109,6 +109,26 @@ class TestDistillAdvantageOverwrite:
         for adv in advantages[1:]:
             assert adv != 0.0  # should be overwritten with distil values
 
+    def test_set_advantage_to_zero_override_survives_distill(self, trainer):
+        """A trajectory flagged with set_advantage_to_zero must have ALL
+        advantages == 0.0 even under distillation. The scalar path honors the
+        override, but the distill branch recomputes advantages from
+        teacher-student deltas; without re-applying the override an excluded
+        trajectory still contributes full distillation gradients."""
+        batch = make_batch(
+            tokens_list=[[1, 2, 3, 4, 5]],
+            logprobs_list=[[1.0, 1.0, -0.5, -0.3, -0.2]],
+            scores=[1.0],
+            distill_token_ids=[[[1], [2], [3], [4], [5]]],
+            distill_logprobs=[[[-0.1], [-0.1], [-0.8], [-0.6], [-0.4]]],
+            overrides=[{"set_advantage_to_zero": True}],
+        )
+
+        datums, _, has_distil = trainer.pad_data_to_good_offset(batch)
+        assert has_distil is True
+        advantages = datums[0].loss_fn_inputs["advantages"].to_torch().tolist()
+        assert all(a == 0.0 for a in advantages)
+
     def test_prompt_tokens_still_masked_in_distill(self, trainer):
         """Prompt sentinel tokens (logprob=1.0) still get 0.0 advantage."""
         batch = make_batch(

--- a/tinker_atropos/trainer.py
+++ b/tinker_atropos/trainer.py
@@ -285,6 +285,20 @@ class TinkerAtroposTrainer:
                         for lp, t_lp in zip(all_logprobs, distil_lps)
                     ]
 
+                    # A trajectory flagged with set_advantage_to_zero must
+                    # contribute no gradient regardless of loss mode. The scalar
+                    # `advantages[i]` was zeroed above, but the distill recompute
+                    # rebuilds all_advantages_padded from teacher-student deltas
+                    # and ignores it — re-apply the exclusion here so the
+                    # override survives distillation.
+                    overrides = item.get("overrides")
+                    if (
+                        overrides is not None
+                        and i < len(overrides)
+                        and overrides[i].get("set_advantage_to_zero", False)
+                    ):
+                        all_advantages_padded = [0.0] * len(all_advantages_padded)
+
                     # Track distil stats (non-prompt tokens only)
                     for lp, t_lp, adv in zip(all_logprobs, distil_lps, all_advantages_padded):
                         if lp != 1.0:  # skip prompt sentinel tokens


### PR DESCRIPTION
## Summary

`pad_data_to_good_offset` supports a per-trajectory `set_advantage_to_zero` override. It zeroes the scalar `advantages[i]` so an excluded trajectory produces no gradient. In the normal RL path that scalar is broadcast into `all_advantages_padded`, so the exclusion survives:

```python
all_advantages_padded = [0.0 if lp == 1.0 else advantage for lp in all_logprobs]
```

The distillation branch rebuilds `all_advantages_padded` from scratch out of per-token teacher−student deltas and never consults the zeroed scalar:

```python
all_advantages_padded = [
    0.0 if lp == 1.0 else float(t_lp - lp)
    for lp, t_lp in zip(all_logprobs, distil_lps)
]
```

So a trajectory explicitly flagged `set_advantage_to_zero` still contributes full per-token distillation gradients.

`test_override_set_advantage_to_zero` (test_logprob_alignment.py) already pins the contract: a flagged trajectory must have all advantages `== 0.0`. That invariant does not depend on the loss mode. Distillation changes how kept advantages are computed, not whether an excluded trajectory stays excluded. The distill branch breaks it.

## Fix

Re-apply the override in the distill branch, right after the teacher−student recompute. It is guarded on `overrides is not None and i < len(overrides)` to match the scalar apply path.

## Distinct from #33

#33 fixes the **group-level** zero-advantage skip (`np.all(advantages == 0)` dropping whole distillation groups). This is the **per-trajectory** `overrides[i]["set_advantage_to_zero"]` flag being ignored inside the distill branch. Different lines, different mechanism.

## Test

`test_set_advantage_to_zero_override_survives_distill` in `tinker_atropos/tests/test_distillation.py`: builds a distill batch with `overrides=[{"set_advantage_to_zero": True}]` and asserts every advantage of that datum is `0.0`. Fails on the current code (they are `t_lp - lp ≠ 0`), passes with the fix. Full `test_distillation.py` suite green (19 tests).